### PR TITLE
Fix build with OpenVR 0.9.10

### DIFF
--- a/osvr_tracked_device.h
+++ b/osvr_tracked_device.h
@@ -25,6 +25,12 @@
 #ifndef INCLUDED_osvr_tracked_device_h_GUID_128E3B29_F5FC_4221_9B38_14E3F402E645
 #define INCLUDED_osvr_tracked_device_h_GUID_128E3B29_F5FC_4221_9B38_14E3F402E645
 
+/// @fixme workaround OpenVR bug!
+namespace vr {
+    typedef unsigned short CameraVideoStreamFormat_e; /// @todo this type is used in the SteamVR drivers
+    typedef unsigned short * CameraVideoStreamFrame_t; /// @todo this type is used in the SteamVR drivers
+}
+
 // Internal Includes
 #include "osvr_compiler_detection.h"
 #include "osvr_display_configuration.h"
@@ -248,6 +254,18 @@ public:
      */
     virtual bool TriggerHapticPulse(uint32_t axis_id, uint16_t pulse_duration_microseconds) OSVR_OVERRIDE;
 
+    // Camera Methods
+    // ------------------------------------
+    virtual bool HasCamera() OSVR_OVERRIDE;
+    virtual bool GetCameraFrameBufferingRequirements( int *pDefaultFrameQueueSize, uint32_t *pFrameBufferDataSize ) OSVR_OVERRIDE;
+    virtual bool SetCameraFrameBuffering( int nFrameBufferCount, void **ppFrameBuffers, uint32_t nFrameBufferDataSize ) OSVR_OVERRIDE;
+    virtual vr::CameraVideoStreamFormat_e GetCameraVideoStreamFormat() OSVR_OVERRIDE;
+    virtual const vr::CameraVideoStreamFrame_t *GetVideoStreamFrame() OSVR_OVERRIDE;
+    virtual void ReleaseVideoStreamFrame( const vr::CameraVideoStreamFrame_t *pFrameImage ) OSVR_OVERRIDE;
+    virtual bool StartVideoStream() OSVR_OVERRIDE;
+    virtual void StopVideoStream() OSVR_OVERRIDE;
+    virtual bool IsVideoStreamActive() OSVR_OVERRIDE;
+    virtual float GetVideoStreamElapsedTime() OSVR_OVERRIDE;
 private:
     static void HmdTrackerCallback(void* userdata, const OSVR_TimeValue* timestamp, const OSVR_PoseReport* report);
     const std::string m_DisplayDescription;
@@ -812,9 +830,63 @@ vr::VRControllerState_t OSVRTrackedDevice::GetControllerState()
 
 bool OSVRTrackedDevice::TriggerHapticPulse(uint32_t axis_id, uint16_t pulse_duration_microseconds)
 {
-    // TODO
+    /// @todo SteamVR drivers return false and do nothing else, doing the same here
     return false;
 }
+
+bool OSVRTrackedDevice::HasCamera()
+{
+    /// @todo SteamVR drivers return false and do nothing else, doing the same here
+    return false;
+}
+
+bool OSVRTrackedDevice::GetCameraFrameBufferingRequirements( int *pDefaultFrameQueueSize, uint32_t *pFrameBufferDataSize )
+{
+    /// @todo SteamVR drivers return false and do nothing else, doing the same here
+    return false;
+}
+bool OSVRTrackedDevice::SetCameraFrameBuffering( int nFrameBufferCount, void **ppFrameBuffers, uint32_t nFrameBufferDataSize )
+{
+    /// @todo SteamVR drivers return false and do nothing else, doing the same here
+    return false;
+}
+vr::CameraVideoStreamFormat_e OSVRTrackedDevice::GetCameraVideoStreamFormat()
+{
+    /// @todo SteamVR drivers return NULL and do nothing else, doing the same here
+    return 0;
+}
+const vr::CameraVideoStreamFrame_t * OSVRTrackedDevice::GetVideoStreamFrame()
+{
+    /// @todo SteamVR drivers return NULL and do nothing else, doing the same here
+    return NULL;
+}
+void OSVRTrackedDevice::ReleaseVideoStreamFrame( const vr::CameraVideoStreamFrame_t *pFrameImage )
+{
+    /// @todo SteamVR drivers does nothing, doing the same here
+}
+
+bool OSVRTrackedDevice::StartVideoStream()
+{
+    /// @todo SteamVR drivers return false and do nothing else, doing the same here
+    return false;
+}
+void OSVRTrackedDevice::StopVideoStream()
+{
+    /// @todo SteamVR drivers does nothing, doing the same here
+}
+bool OSVRTrackedDevice::IsVideoStreamActive()
+{
+    /// @todo SteamVR drivers return false and do nothing else, doing the same here
+    return false;
+}
+float OSVRTrackedDevice::GetVideoStreamElapsedTime()
+{
+    /// @todo SteamVR drivers return 0 and do nothing else, doing the same here
+    return 0;
+}
+
+
+
 
 void OSVRTrackedDevice::HmdTrackerCallback(void* userdata, const OSVR_TimeValue* timestamp, const OSVR_PoseReport* report)
 {


### PR DESCRIPTION
All of these new methods return 0 or NULL, or do nothing, in Valve's own drivers.

The workaround should not be necessary after Valve fixes https://github.com/ValveSoftware/openvr/issues/28. Right now it is necessary. The return types were determined by looking at the exported symbols from the lib.