### PR TITLE
Use submodule for SteamVR dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,3 @@
 # Build directory
 build
 
-# openvr repo
-openvr

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "openvr"]
+	path = openvr
+	url = https://github.com/ValveSoftware/openvr.git

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Note that despite similar goals, the internal models of the two systems are not 
 		- headers-only is fine: no compiled libraries are required
 	- [jsoncpp][]
 		- prebuilt Visual Studio binaries available at <http://access.osvr.com/binary/deps/jsoncpp>
-- An installation of the [Valve Software OpenVR SDK][openvr] - right now the repo is a binary distribution, so you can just clone the repo.
-	- If you name the directory `openvr` (which is the default when cloning with git) and place it next to or within this project's root directory, CMake will be able to find it automatically.
-	- As of the moment this file is committed, the latest version works (and may be required). They're iterating the SDK and changing APIs rapidly, so if you have compile issues, you may have to look at the git history and either use an older version or update this project to match.
+- An installation of the [Valve Software OpenVR SDK][openvr]
+    - This is currently provided as a git submodule.
+    - Run ```git submodule --init --update``` to download the OpenVR SDK.
 
 ### Building
 


### PR DESCRIPTION
This switches to using a submodule for the SteamVR/OpenVR headers and libraries. If you want to make a private fork of that repo and use that instead, feel free to make the needed changes.