### PR TITLE
Build as shared lib so that name is correct on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,13 @@ add_subdirectory(vendor)
 
 
 # Disable 'lib' prefix on POSIX systems
-set(CMAKE_SHARED_MODULE_PREFIX "")
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
 #
 # OpenVR driver
 #
 add_library(driver_osvr
-	MODULE
+	SHARED
 	ClientDriver_OSVR.h
 	driver_osvr.cpp
 	identity.h


### PR DESCRIPTION
Mac OS X expects all libs to be named .dylib (I have no idea why CMake still uses .so — that's used barely anywhere). This fixes things so that they are as expected on OS X, and should not break other operating systems (I think, have not tested).

rpath fixes will come in a later PR. Right now that's not critically important.