### PR TITLE
Remove unneeded jsoncpp dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ list(APPEND CMAKE_PREFIX_PATH
 #
 find_package(OpenVR REQUIRED)
 find_package(osvr REQUIRED)
-find_package(jsoncpp REQUIRED)
-if(TARGET jsoncpp_lib_static AND NOT TARGET jsoncpp_lib)
-	add_library(jsoncpp_lib ALIAS jsoncpp_lib_static)
-endif()
 
 find_package(Threads REQUIRED)
 find_package(Boost REQUIRED)
@@ -70,7 +66,7 @@ add_library(driver_osvr
 	osvr_tracked_device.h
 	ServerDriver_OSVR.h
 )
-target_link_libraries(driver_osvr PRIVATE osvr::osvrClientKitCpp eigen-headers util-headers jsoncpp_lib)
+target_link_libraries(driver_osvr PRIVATE osvr::osvrClientKitCpp eigen-headers util-headers)
 target_include_directories(driver_osvr PRIVATE ${OPENVR_INCLUDE_DIRS})
 set_property(TARGET driver_osvr PROPERTY CXX_STANDARD 11)
 target_compile_features(driver_osvr PRIVATE cxx_override)
@@ -106,7 +102,7 @@ endif()
 # Test program
 #
 add_executable(test_hmd_driver test_hmd_driver.cpp)
-target_link_libraries(test_hmd_driver PRIVATE osvr::osvrClientKitCpp eigen-headers util-headers jsoncpp_lib)
+target_link_libraries(test_hmd_driver PRIVATE osvr::osvrClientKitCpp eigen-headers util-headers)
 if(NOT OSVR_HAS_STD_MAKE_UNIQUE)
 	target_link_libraries(test_hmd_driver PRIVATE make-unique-impl-header)
 endif()

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ In this example, we'll use TF2, which has it accessible in its menu: go to "Opti
 		- Windows snapshot builds are available at <http://access.osvr.com/binary/osvr-core>
 	- [Boost][]
 		- headers-only is fine: no compiled libraries are required
-	- [jsoncpp][]
-		- prebuilt Visual Studio binaries available at <http://access.osvr.com/binary/deps/jsoncpp>
 - An installation of the [Valve Software OpenVR SDK][openvr]
     - This is currently provided as a git submodule.
     - Run `git submodule update --init --recursive` to download the OpenVR SDK.
@@ -104,7 +102,6 @@ As mentioned above, the `install` target will place the driver binary in a speci
 [CMake]: http://cmake.org
 [OSVR-Core]: https://github.com/OSVR/OSVR-Core
 [Boost]: http://boost.org
-[jsoncpp]: https://github.com/open-source-parsers/jsoncpp
 [openvr]: https://github.com/ValveSoftware/openvr
 [libc++]: http://libcxx.llvm.org/
 [util-headers]: https://github.com/rpavlik/util-headers


### PR DESCRIPTION
This dependency is no longer needed and makes building SteamVR-OSVR more annoying than it should be.