### PR TITLE
Fix vr::ETrackedDeviceProperty switches

### DIFF
--- a/osvr_device_properties.h
+++ b/osvr_device_properties.h
@@ -44,12 +44,12 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
     case vr::Prop_IsOnDesktop_Bool:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-	case vr::Prop_Firmware_UpdateAvailable_Bool: 
-	case vr::Prop_Firmware_ManualUpdate_Bool: 
-	case vr::Prop_BlockServerShutdown_Bool: 
-	case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool: 
-	case vr::Prop_ContainsProximitySensor_Bool: 
-	case vr::Prop_DeviceProvidesBatteryStatus_Bool: 
+    case vr::Prop_Firmware_UpdateAvailable_Bool: 
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool: 
         return false;
     case vr::Prop_TrackingSystemName_String:
@@ -112,7 +112,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
     default:
-		return true;
+        return true;
     }
 }
 
@@ -129,17 +129,17 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
     case vr::Prop_DeviceBatteryPercentage_Float:
-	case vr::Prop_DisplayMCOffset_Float:
-	case vr::Prop_DisplayMCScale_Float:
-	case vr::Prop_DisplayGCBlackClamp_Float:
-	case vr::Prop_DisplayGCOffset_Float:
-	case vr::Prop_DisplayGCScale_Float:
-	case vr::Prop_DisplayGCPrescale_Float:
-	case vr::Prop_LensCenterLeftU_Float:
-	case vr::Prop_LensCenterLeftV_Float:
-	case vr::Prop_LensCenterRightU_Float:
-	case vr::Prop_LensCenterRightV_Float:
-	case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
         return false;
     case vr::Prop_TrackingSystemName_String:
     case vr::Prop_ModelNumber_String:
@@ -192,7 +192,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
     default:
-		return true;
+        return true;
     }
 }
 
@@ -204,10 +204,10 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const int32_t&)
     case vr::Prop_Axis2Type_Int32:
     case vr::Prop_Axis3Type_Int32:
     case vr::Prop_Axis4Type_Int32:
-	case vr::Prop_DisplayMCType_Int32:
-	case vr::Prop_EdidVendorID_Int32:
-	case vr::Prop_EdidProductID_Int32:
-	case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
         return false;
     case vr::Prop_TrackingSystemName_String:
     case vr::Prop_ModelNumber_String:
@@ -272,7 +272,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const int32_t&)
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
     default:
-		return true;
+        return true;
     }
 }
 
@@ -282,13 +282,13 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const uint64_t&)
     case vr::Prop_CurrentUniverseId_Uint64:
     case vr::Prop_PreviousUniverseId_Uint64:
     case vr::Prop_SupportedButtons_Uint64:
-	case vr::Prop_HardwareRevision_Uint64:
-	case vr::Prop_FirmwareVersion_Uint64:
-	case vr::Prop_FPGAVersion_Uint64:
-	case vr::Prop_VRCVersion_Uint64:
-	case vr::Prop_RadioVersion_Uint64:
-	case vr::Prop_DongleVersion_Uint64:
-	case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
         return false;
     case vr::Prop_TrackingSystemName_String:
     case vr::Prop_ModelNumber_String:
@@ -352,7 +352,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const uint64_t&)
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
     default:
-		return true;
+        return true;
     }
 }
 
@@ -370,10 +370,10 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
     case vr::Prop_AttachedDeviceId_String:
     case vr::Prop_AllWirelessDongleDescriptions_String:
     case vr::Prop_ConnectedWirelessDongle_String:
-	case vr::Prop_Firmware_ManualUpdateURL_String:
-	case vr::Prop_DisplayMCImageLeft_String:
-	case vr::Prop_DisplayMCImageRight_String:
-	case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCImage_String:
         return false;
     case vr::Prop_WillDriftInYaw_Bool:
     case vr::Prop_DeviceIsWireless_Bool:
@@ -432,7 +432,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
     default:
-		return true;
+        return true;
     }
 }
 
@@ -441,7 +441,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, vr::HmdMatrix34_t)
     switch (prop)
     {
     case vr::Prop_StatusDisplayTransform_Matrix34:
-	case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
         return false;
     case vr::Prop_TrackingSystemName_String:
     case vr::Prop_ModelNumber_String:
@@ -513,7 +513,7 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, vr::HmdMatrix34_t)
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
     default:
-		return true;
+        return true;
     }
 }
 
@@ -535,42 +535,42 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_DeviceIsCharging_Bool:
     case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_StatusDisplayTransform_Matrix34:
-	case vr::Prop_Firmware_UpdateAvailable_Bool:
-	case vr::Prop_Firmware_ManualUpdate_Bool: 
-	case vr::Prop_Firmware_ManualUpdateURL_String:
-	case vr::Prop_HardwareRevision_Uint64: 
-	case vr::Prop_FirmwareVersion_Uint64: 
-	case vr::Prop_FPGAVersion_Uint64: 
-	case vr::Prop_VRCVersion_Uint64: 
-	case vr::Prop_RadioVersion_Uint64:
-	case vr::Prop_DongleVersion_Uint64:
-	case vr::Prop_BlockServerShutdown_Bool:
-	case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
-	case vr::Prop_ContainsProximitySensor_Bool: 
-	case vr::Prop_DeviceProvidesBatteryStatus_Bool: 
-	case vr::Prop_DeviceCanPowerOff_Bool:
-	case vr::Prop_DisplayMCType_Int32: 
-	case vr::Prop_DisplayMCOffset_Float: 
-	case vr::Prop_DisplayMCScale_Float:
-	case vr::Prop_EdidVendorID_Int32: 
-	case vr::Prop_DisplayMCImageLeft_String: 
-	case vr::Prop_DisplayMCImageRight_String: 
-	case vr::Prop_DisplayGCBlackClamp_Float: 
-	case vr::Prop_EdidProductID_Int32:
-	case vr::Prop_CameraToHeadTransform_Matrix34:
-	case vr::Prop_DisplayGCType_Int32:
-	case vr::Prop_DisplayGCOffset_Float:
-	case vr::Prop_DisplayGCScale_Float:
-	case vr::Prop_DisplayGCPrescale_Float:
-	case vr::Prop_DisplayGCImage_String:
-	case vr::Prop_LensCenterLeftU_Float:
-	case vr::Prop_LensCenterLeftV_Float:
-	case vr::Prop_LensCenterRightU_Float:
-	case vr::Prop_LensCenterRightV_Float:
-	case vr::Prop_UserHeadToEyeDepthMeters_Float:
-	case vr::Prop_CameraFirmwareVersion_Uint64:
-	case vr::Prop_VendorSpecific_Reserved_Start:
-	case vr::Prop_VendorSpecific_Reserved_End:
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
 
     // Properties that are unique to TrackedDeviceClass_HMD

--- a/osvr_device_properties.h
+++ b/osvr_device_properties.h
@@ -34,27 +34,90 @@
 // Standard includes
 // - none
 
+// Whenever you upgrade OpenVR, make sure you update all the functions below if vr::ETrackedDeviceProperty has changed.
+
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
     switch (prop) {
     case vr::Prop_WillDriftInYaw_Bool:
     case vr::Prop_ReportsTimeSinceVSync_Bool:
     case vr::Prop_IsOnDesktop_Bool:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
+	case vr::Prop_Firmware_UpdateAvailable_Bool: 
+	case vr::Prop_Firmware_ManualUpdate_Bool: 
+	case vr::Prop_BlockServerShutdown_Bool: 
+	case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool: 
+	case vr::Prop_ContainsProximitySensor_Bool: 
+	case vr::Prop_DeviceProvidesBatteryStatus_Bool: 
+    case vr::Prop_DeviceCanPowerOff_Bool: 
         return false;
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_DeviceBatteryPercentage_Float:
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_String:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_SupportedButtons_Uint64:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
+    default:
+		return true;
     }
-#include "ignore-warning/pop"
-
-    return true;
 }
 
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
     switch (prop) {
     case vr::Prop_SecondsFromVsyncToPhotons_Float:
     case vr::Prop_DisplayFrequency_Float:
@@ -66,49 +129,235 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
     case vr::Prop_DeviceBatteryPercentage_Float:
+	case vr::Prop_DisplayMCOffset_Float:
+	case vr::Prop_DisplayMCScale_Float:
+	case vr::Prop_DisplayGCBlackClamp_Float:
+	case vr::Prop_DisplayGCOffset_Float:
+	case vr::Prop_DisplayGCScale_Float:
+	case vr::Prop_DisplayGCPrescale_Float:
+	case vr::Prop_LensCenterLeftU_Float:
+	case vr::Prop_LensCenterLeftV_Float:
+	case vr::Prop_LensCenterRightU_Float:
+	case vr::Prop_LensCenterRightV_Float:
+	case vr::Prop_UserHeadToEyeDepthMeters_Float:
         return false;
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_WillDriftInYaw_Bool:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_DeviceIsWireless_Bool:
+    case vr::Prop_DeviceIsCharging_Bool:
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_String:
+    case vr::Prop_IsOnDesktop_Bool:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_SupportedButtons_Uint64:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
+    default:
+		return true;
     }
-#include "ignore-warning/pop"
-
-    return true;
 }
 
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const int32_t&)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
     switch (prop) {
     case vr::Prop_Axis0Type_Int32:
     case vr::Prop_Axis1Type_Int32:
     case vr::Prop_Axis2Type_Int32:
     case vr::Prop_Axis3Type_Int32:
     case vr::Prop_Axis4Type_Int32:
+	case vr::Prop_DisplayMCType_Int32:
+	case vr::Prop_EdidVendorID_Int32:
+	case vr::Prop_EdidProductID_Int32:
+	case vr::Prop_DisplayGCType_Int32:
         return false;
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_WillDriftInYaw_Bool:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_DeviceIsWireless_Bool:
+    case vr::Prop_DeviceIsCharging_Bool:
+    case vr::Prop_DeviceBatteryPercentage_Float:
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_String:
+    case vr::Prop_IsOnDesktop_Bool:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_SupportedButtons_Uint64:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
+    default:
+		return true;
     }
-#include "ignore-warning/pop"
-
-    return true;
 }
 
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const uint64_t&)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
     switch (prop) {
     case vr::Prop_CurrentUniverseId_Uint64:
     case vr::Prop_PreviousUniverseId_Uint64:
     case vr::Prop_SupportedButtons_Uint64:
+	case vr::Prop_HardwareRevision_Uint64:
+	case vr::Prop_FirmwareVersion_Uint64:
+	case vr::Prop_FPGAVersion_Uint64:
+	case vr::Prop_VRCVersion_Uint64:
+	case vr::Prop_RadioVersion_Uint64:
+	case vr::Prop_DongleVersion_Uint64:
+	case vr::Prop_CameraFirmwareVersion_Uint64:
         return false;
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_WillDriftInYaw_Bool:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_DeviceIsWireless_Bool:
+    case vr::Prop_DeviceIsCharging_Bool:
+    case vr::Prop_DeviceBatteryPercentage_Float:
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_DisplayFirmwareVersion_String:
+    case vr::Prop_IsOnDesktop_Bool:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
+    default:
+		return true;
     }
-#include "ignore-warning/pop"
-
-    return true;
 }
 
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
     switch (prop) {
     case vr::Prop_TrackingSystemName_String:
     case vr::Prop_ModelNumber_String:
@@ -121,30 +370,155 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
     case vr::Prop_AttachedDeviceId_String:
     case vr::Prop_AllWirelessDongleDescriptions_String:
     case vr::Prop_ConnectedWirelessDongle_String:
+	case vr::Prop_Firmware_ManualUpdateURL_String:
+	case vr::Prop_DisplayMCImageLeft_String:
+	case vr::Prop_DisplayMCImageRight_String:
+	case vr::Prop_DisplayGCImage_String:
         return false;
+    case vr::Prop_WillDriftInYaw_Bool:
+    case vr::Prop_DeviceIsWireless_Bool:
+    case vr::Prop_DeviceIsCharging_Bool:
+    case vr::Prop_DeviceBatteryPercentage_Float:
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_IsOnDesktop_Bool:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
+    default:
+		return true;
     }
-#include "ignore-warning/pop"
-
-    return true;
 }
 
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, vr::HmdMatrix34_t)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
-    switch (prop) {
+    switch (prop)
+    {
     case vr::Prop_StatusDisplayTransform_Matrix34:
+	case vr::Prop_CameraToHeadTransform_Matrix34:
         return false;
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_WillDriftInYaw_Bool:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_DeviceIsWireless_Bool:
+    case vr::Prop_DeviceIsCharging_Bool:
+    case vr::Prop_DeviceBatteryPercentage_Float:
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
+    case vr::Prop_Firmware_ManualUpdate_Bool:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_BlockServerShutdown_Bool:
+    case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+    case vr::Prop_ContainsProximitySensor_Bool:
+    case vr::Prop_DeviceProvidesBatteryStatus_Bool:
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_String:
+    case vr::Prop_IsOnDesktop_Bool:
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_SupportedButtons_Uint64:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
+    default:
+		return true;
     }
-#include "ignore-warning/pop"
-
-    return true;
 }
 
 inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDeviceClass device_class)
 {
-#include "ignore-warning/push"
-#include "ignore-warning/switch-enum"
     switch (prop) {
     // General properties that apply to all device classes
     case vr::Prop_TrackingSystemName_String:
@@ -161,6 +535,42 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_DeviceIsCharging_Bool:
     case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_StatusDisplayTransform_Matrix34:
+	case vr::Prop_Firmware_UpdateAvailable_Bool:
+	case vr::Prop_Firmware_ManualUpdate_Bool: 
+	case vr::Prop_Firmware_ManualUpdateURL_String:
+	case vr::Prop_HardwareRevision_Uint64: 
+	case vr::Prop_FirmwareVersion_Uint64: 
+	case vr::Prop_FPGAVersion_Uint64: 
+	case vr::Prop_VRCVersion_Uint64: 
+	case vr::Prop_RadioVersion_Uint64:
+	case vr::Prop_DongleVersion_Uint64:
+	case vr::Prop_BlockServerShutdown_Bool:
+	case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
+	case vr::Prop_ContainsProximitySensor_Bool: 
+	case vr::Prop_DeviceProvidesBatteryStatus_Bool: 
+	case vr::Prop_DeviceCanPowerOff_Bool:
+	case vr::Prop_DisplayMCType_Int32: 
+	case vr::Prop_DisplayMCOffset_Float: 
+	case vr::Prop_DisplayMCScale_Float:
+	case vr::Prop_EdidVendorID_Int32: 
+	case vr::Prop_DisplayMCImageLeft_String: 
+	case vr::Prop_DisplayMCImageRight_String: 
+	case vr::Prop_DisplayGCBlackClamp_Float: 
+	case vr::Prop_EdidProductID_Int32:
+	case vr::Prop_CameraToHeadTransform_Matrix34:
+	case vr::Prop_DisplayGCType_Int32:
+	case vr::Prop_DisplayGCOffset_Float:
+	case vr::Prop_DisplayGCScale_Float:
+	case vr::Prop_DisplayGCPrescale_Float:
+	case vr::Prop_DisplayGCImage_String:
+	case vr::Prop_LensCenterLeftU_Float:
+	case vr::Prop_LensCenterLeftV_Float:
+	case vr::Prop_LensCenterRightU_Float:
+	case vr::Prop_LensCenterRightV_Float:
+	case vr::Prop_UserHeadToEyeDepthMeters_Float:
+	case vr::Prop_CameraFirmwareVersion_Uint64:
+	case vr::Prop_VendorSpecific_Reserved_Start:
+	case vr::Prop_VendorSpecific_Reserved_End:
         return false;
 
     // Properties that are unique to TrackedDeviceClass_HMD
@@ -172,7 +582,7 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_PreviousUniverseId_Uint64:
     case vr::Prop_DisplayFirmwareVersion_String:
     case vr::Prop_IsOnDesktop_Bool:
-        return (vr::TrackedDeviceClass_HMD == device_class);
+        return (vr::TrackedDeviceClass_HMD != device_class);
 
     // Properties that are unique to TrackedDeviceClass_Controller
     case vr::Prop_AttachedDeviceId_String:
@@ -182,7 +592,7 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_Axis2Type_Int32:
     case vr::Prop_Axis3Type_Int32:
     case vr::Prop_Axis4Type_Int32:
-        return (vr::TrackedDeviceClass_Controller == device_class);
+        return (vr::TrackedDeviceClass_Controller != device_class);
 
     // Properties that are unique to TrackedDeviceClass_TrackingReference
     case vr::Prop_FieldOfViewLeftDegrees_Float:
@@ -191,12 +601,11 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
-        return (vr::TrackedDeviceClass_TrackingReference == device_class);
+        return (vr::TrackedDeviceClass_TrackingReference != device_class);
 
     default:
         return true;
     }
-#include "ignore-warning/pop"
 }
 
 #endif // INCLUDED_osvr_device_properties_h_GUID_5212DE9D_B211_4139_A140_45A578EFA47E


### PR DESCRIPTION
Add ALL members of vr::ETrackedDeviceProperty to the wrong data type and class type checks

Remove the warning ignores, because it will result in bugs in the future

Add warning for OpenVR upgrades which may affect enums (ideally should be a compile time check or warnings as errors)

Fix isWrongDeviceClass to return false for correct classes, and true otherwise

This also fixes https://github.com/OSVR/SteamVR-OSVR/issues/22 , and now you can play SteamVR games through OSVR :D