### PR TITLE
Allow to compile with SteamVR-OpenVR 0.9.15

### DIFF
--- a/osvr_device_properties.h
+++ b/osvr_device_properties.h
@@ -40,18 +40,67 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
 {
     switch (prop) {
     case vr::Prop_WillDriftInYaw_Bool:
-    case vr::Prop_ReportsTimeSinceVSync_Bool:
-    case vr::Prop_IsOnDesktop_Bool:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-    case vr::Prop_Firmware_UpdateAvailable_Bool: 
+    case vr::Prop_Firmware_UpdateAvailable_Bool:
     case vr::Prop_Firmware_ManualUpdate_Bool:
     case vr::Prop_BlockServerShutdown_Bool:
     case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
-    case vr::Prop_DeviceCanPowerOff_Bool: 
+    case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_IsOnDesktop_Bool:
+    // could be any type
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
+    // Float
+    case vr::Prop_DeviceBatteryPercentage_Float:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_DisplayMCOffset_Float:
+    case vr::Prop_DisplayMCScale_Float:
+    case vr::Prop_DisplayGCBlackClamp_Float:
+    case vr::Prop_DisplayGCOffset_Float:
+    case vr::Prop_DisplayGCScale_Float:
+    case vr::Prop_DisplayGCPrescale_Float:
+    case vr::Prop_LensCenterLeftU_Float:
+    case vr::Prop_LensCenterLeftV_Float:
+    case vr::Prop_LensCenterRightU_Float:
+    case vr::Prop_LensCenterRightV_Float:
+    case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    // Int32
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    // Uint64
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    // String
     case vr::Prop_TrackingSystemName_String:
     case vr::Prop_ModelNumber_String:
     case vr::Prop_SerialNumber_String:
@@ -61,57 +110,17 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
     case vr::Prop_HardwareRevision_String:
     case vr::Prop_AllWirelessDongleDescriptions_String:
     case vr::Prop_ConnectedWirelessDongle_String:
-    case vr::Prop_DeviceBatteryPercentage_Float:
-    case vr::Prop_StatusDisplayTransform_Matrix34:
     case vr::Prop_Firmware_ManualUpdateURL_String:
-    case vr::Prop_HardwareRevision_Uint64:
-    case vr::Prop_FirmwareVersion_Uint64:
-    case vr::Prop_FPGAVersion_Uint64:
-    case vr::Prop_VRCVersion_Uint64:
-    case vr::Prop_RadioVersion_Uint64:
-    case vr::Prop_DongleVersion_Uint64:
-    case vr::Prop_SecondsFromVsyncToPhotons_Float:
-    case vr::Prop_DisplayFrequency_Float:
-    case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_DisplayFirmwareVersion_String:
-    case vr::Prop_DisplayMCType_Int32:
-    case vr::Prop_DisplayMCOffset_Float:
-    case vr::Prop_DisplayMCScale_Float:
-    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
     case vr::Prop_DisplayMCImageLeft_String:
     case vr::Prop_DisplayMCImageRight_String:
-    case vr::Prop_DisplayGCBlackClamp_Float:
-    case vr::Prop_EdidProductID_Int32:
-    case vr::Prop_CameraToHeadTransform_Matrix34:
-    case vr::Prop_DisplayGCType_Int32:
-    case vr::Prop_DisplayGCOffset_Float:
-    case vr::Prop_DisplayGCScale_Float:
-    case vr::Prop_DisplayGCPrescale_Float:
     case vr::Prop_DisplayGCImage_String:
-    case vr::Prop_LensCenterLeftU_Float:
-    case vr::Prop_LensCenterLeftV_Float:
-    case vr::Prop_LensCenterRightU_Float:
-    case vr::Prop_LensCenterRightV_Float:
-    case vr::Prop_UserHeadToEyeDepthMeters_Float:
-    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_CameraFirmwareDescription_String:
     case vr::Prop_AttachedDeviceId_String:
-    case vr::Prop_SupportedButtons_Uint64:
-    case vr::Prop_Axis0Type_Int32:
-    case vr::Prop_Axis1Type_Int32:
-    case vr::Prop_Axis2Type_Int32:
-    case vr::Prop_Axis3Type_Int32:
-    case vr::Prop_Axis4Type_Int32:
-    case vr::Prop_FieldOfViewLeftDegrees_Float:
-    case vr::Prop_FieldOfViewRightDegrees_Float:
-    case vr::Prop_FieldOfViewTopDegrees_Float:
-    case vr::Prop_FieldOfViewBottomDegrees_Float:
-    case vr::Prop_TrackingRangeMinimumMeters_Float:
-    case vr::Prop_TrackingRangeMaximumMeters_Float:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-    default:
+    case vr::Prop_ModeLabel_String:
+    // Matrix34
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
         return true;
     }
 }
@@ -119,16 +128,10 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
 {
     switch (prop) {
+    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_SecondsFromVsyncToPhotons_Float:
     case vr::Prop_DisplayFrequency_Float:
     case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_FieldOfViewLeftDegrees_Float:
-    case vr::Prop_FieldOfViewRightDegrees_Float:
-    case vr::Prop_FieldOfViewTopDegrees_Float:
-    case vr::Prop_FieldOfViewBottomDegrees_Float:
-    case vr::Prop_TrackingRangeMinimumMeters_Float:
-    case vr::Prop_TrackingRangeMaximumMeters_Float:
-    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_DisplayMCOffset_Float:
     case vr::Prop_DisplayMCScale_Float:
     case vr::Prop_DisplayGCBlackClamp_Float:
@@ -140,58 +143,73 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
     case vr::Prop_LensCenterRightU_Float:
     case vr::Prop_LensCenterRightV_Float:
     case vr::Prop_UserHeadToEyeDepthMeters_Float:
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+    // could be any type
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
-    case vr::Prop_TrackingSystemName_String:
-    case vr::Prop_ModelNumber_String:
-    case vr::Prop_SerialNumber_String:
-    case vr::Prop_RenderModelName_String:
+    // Bool
     case vr::Prop_WillDriftInYaw_Bool:
-    case vr::Prop_ManufacturerName_String:
-    case vr::Prop_TrackingFirmwareVersion_String:
-    case vr::Prop_HardwareRevision_String:
-    case vr::Prop_AllWirelessDongleDescriptions_String:
-    case vr::Prop_ConnectedWirelessDongle_String:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-    case vr::Prop_StatusDisplayTransform_Matrix34:
     case vr::Prop_Firmware_UpdateAvailable_Bool:
     case vr::Prop_Firmware_ManualUpdate_Bool:
-    case vr::Prop_Firmware_ManualUpdateURL_String:
-    case vr::Prop_HardwareRevision_Uint64:
-    case vr::Prop_FirmwareVersion_Uint64:
-    case vr::Prop_FPGAVersion_Uint64:
-    case vr::Prop_VRCVersion_Uint64:
-    case vr::Prop_RadioVersion_Uint64:
-    case vr::Prop_DongleVersion_Uint64:
     case vr::Prop_BlockServerShutdown_Bool:
     case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool:
     case vr::Prop_ReportsTimeSinceVSync_Bool:
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_DisplayFirmwareVersion_String:
     case vr::Prop_IsOnDesktop_Bool:
+    // Int32
     case vr::Prop_DisplayMCType_Int32:
     case vr::Prop_EdidVendorID_Int32:
-    case vr::Prop_DisplayMCImageLeft_String:
-    case vr::Prop_DisplayMCImageRight_String:
     case vr::Prop_EdidProductID_Int32:
-    case vr::Prop_CameraToHeadTransform_Matrix34:
     case vr::Prop_DisplayGCType_Int32:
-    case vr::Prop_DisplayGCImage_String:
-    case vr::Prop_CameraFirmwareVersion_Uint64:
-    case vr::Prop_AttachedDeviceId_String:
-    case vr::Prop_SupportedButtons_Uint64:
     case vr::Prop_Axis0Type_Int32:
     case vr::Prop_Axis1Type_Int32:
     case vr::Prop_Axis2Type_Int32:
     case vr::Prop_Axis3Type_Int32:
     case vr::Prop_Axis4Type_Int32:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-    default:
+    // Uint64
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    // String
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_CameraFirmwareDescription_String:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_ModeLabel_String:
+    // Matrix34
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
         return true;
     }
 }
@@ -199,79 +217,88 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const int32_t&)
 {
     switch (prop) {
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
     case vr::Prop_Axis0Type_Int32:
     case vr::Prop_Axis1Type_Int32:
     case vr::Prop_Axis2Type_Int32:
     case vr::Prop_Axis3Type_Int32:
     case vr::Prop_Axis4Type_Int32:
-    case vr::Prop_DisplayMCType_Int32:
-    case vr::Prop_EdidVendorID_Int32:
-    case vr::Prop_EdidProductID_Int32:
-    case vr::Prop_DisplayGCType_Int32:
+    // could be any type
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
-    case vr::Prop_TrackingSystemName_String:
-    case vr::Prop_ModelNumber_String:
-    case vr::Prop_SerialNumber_String:
-    case vr::Prop_RenderModelName_String:
+    // Bool
     case vr::Prop_WillDriftInYaw_Bool:
-    case vr::Prop_ManufacturerName_String:
-    case vr::Prop_TrackingFirmwareVersion_String:
-    case vr::Prop_HardwareRevision_String:
-    case vr::Prop_AllWirelessDongleDescriptions_String:
-    case vr::Prop_ConnectedWirelessDongle_String:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-    case vr::Prop_DeviceBatteryPercentage_Float:
-    case vr::Prop_StatusDisplayTransform_Matrix34:
     case vr::Prop_Firmware_UpdateAvailable_Bool:
     case vr::Prop_Firmware_ManualUpdate_Bool:
-    case vr::Prop_Firmware_ManualUpdateURL_String:
-    case vr::Prop_HardwareRevision_Uint64:
-    case vr::Prop_FirmwareVersion_Uint64:
-    case vr::Prop_FPGAVersion_Uint64:
-    case vr::Prop_VRCVersion_Uint64:
-    case vr::Prop_RadioVersion_Uint64:
-    case vr::Prop_DongleVersion_Uint64:
     case vr::Prop_BlockServerShutdown_Bool:
     case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool:
     case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_IsOnDesktop_Bool:
+    // Float
+    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_SecondsFromVsyncToPhotons_Float:
     case vr::Prop_DisplayFrequency_Float:
     case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_DisplayFirmwareVersion_String:
-    case vr::Prop_IsOnDesktop_Bool:
     case vr::Prop_DisplayMCOffset_Float:
     case vr::Prop_DisplayMCScale_Float:
-    case vr::Prop_DisplayMCImageLeft_String:
-    case vr::Prop_DisplayMCImageRight_String:
     case vr::Prop_DisplayGCBlackClamp_Float:
-    case vr::Prop_CameraToHeadTransform_Matrix34:
     case vr::Prop_DisplayGCOffset_Float:
     case vr::Prop_DisplayGCScale_Float:
     case vr::Prop_DisplayGCPrescale_Float:
-    case vr::Prop_DisplayGCImage_String:
     case vr::Prop_LensCenterLeftU_Float:
     case vr::Prop_LensCenterLeftV_Float:
     case vr::Prop_LensCenterRightU_Float:
     case vr::Prop_LensCenterRightV_Float:
     case vr::Prop_UserHeadToEyeDepthMeters_Float:
-    case vr::Prop_CameraFirmwareVersion_Uint64:
-    case vr::Prop_AttachedDeviceId_String:
-    case vr::Prop_SupportedButtons_Uint64:
     case vr::Prop_FieldOfViewLeftDegrees_Float:
     case vr::Prop_FieldOfViewRightDegrees_Float:
     case vr::Prop_FieldOfViewTopDegrees_Float:
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-    default:
+    // Uint64
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    // String
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_CameraFirmwareDescription_String:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_ModeLabel_String:
+    // Matrix34
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
         return true;
     }
 }
@@ -279,79 +306,88 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const int32_t&)
 inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const uint64_t&)
 {
     switch (prop) {
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_SupportedButtons_Uint64:
     case vr::Prop_HardwareRevision_Uint64:
     case vr::Prop_FirmwareVersion_Uint64:
     case vr::Prop_FPGAVersion_Uint64:
     case vr::Prop_VRCVersion_Uint64:
     case vr::Prop_RadioVersion_Uint64:
     case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
     case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    // could be any type
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
-    case vr::Prop_TrackingSystemName_String:
-    case vr::Prop_ModelNumber_String:
-    case vr::Prop_SerialNumber_String:
-    case vr::Prop_RenderModelName_String:
+    // Bool
     case vr::Prop_WillDriftInYaw_Bool:
-    case vr::Prop_ManufacturerName_String:
-    case vr::Prop_TrackingFirmwareVersion_String:
-    case vr::Prop_HardwareRevision_String:
-    case vr::Prop_AllWirelessDongleDescriptions_String:
-    case vr::Prop_ConnectedWirelessDongle_String:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-    case vr::Prop_DeviceBatteryPercentage_Float:
-    case vr::Prop_StatusDisplayTransform_Matrix34:
     case vr::Prop_Firmware_UpdateAvailable_Bool:
     case vr::Prop_Firmware_ManualUpdate_Bool:
-    case vr::Prop_Firmware_ManualUpdateURL_String:
     case vr::Prop_BlockServerShutdown_Bool:
     case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool:
     case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_IsOnDesktop_Bool:
+    // Float
+    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_SecondsFromVsyncToPhotons_Float:
     case vr::Prop_DisplayFrequency_Float:
     case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_DisplayFirmwareVersion_String:
-    case vr::Prop_IsOnDesktop_Bool:
-    case vr::Prop_DisplayMCType_Int32:
     case vr::Prop_DisplayMCOffset_Float:
     case vr::Prop_DisplayMCScale_Float:
-    case vr::Prop_EdidVendorID_Int32:
-    case vr::Prop_DisplayMCImageLeft_String:
-    case vr::Prop_DisplayMCImageRight_String:
     case vr::Prop_DisplayGCBlackClamp_Float:
-    case vr::Prop_EdidProductID_Int32:
-    case vr::Prop_CameraToHeadTransform_Matrix34:
-    case vr::Prop_DisplayGCType_Int32:
     case vr::Prop_DisplayGCOffset_Float:
     case vr::Prop_DisplayGCScale_Float:
     case vr::Prop_DisplayGCPrescale_Float:
-    case vr::Prop_DisplayGCImage_String:
     case vr::Prop_LensCenterLeftU_Float:
     case vr::Prop_LensCenterLeftV_Float:
     case vr::Prop_LensCenterRightU_Float:
     case vr::Prop_LensCenterRightV_Float:
     case vr::Prop_UserHeadToEyeDepthMeters_Float:
-    case vr::Prop_AttachedDeviceId_String:
-    case vr::Prop_Axis0Type_Int32:
-    case vr::Prop_Axis1Type_Int32:
-    case vr::Prop_Axis2Type_Int32:
-    case vr::Prop_Axis3Type_Int32:
-    case vr::Prop_Axis4Type_Int32:
     case vr::Prop_FieldOfViewLeftDegrees_Float:
     case vr::Prop_FieldOfViewRightDegrees_Float:
     case vr::Prop_FieldOfViewTopDegrees_Float:
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-    default:
+    // Int32
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    // String
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_CameraFirmwareDescription_String:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_ModeLabel_String:
+    // Matrix34
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
         return true;
     }
 }
@@ -366,48 +402,41 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
     case vr::Prop_ManufacturerName_String:
     case vr::Prop_TrackingFirmwareVersion_String:
     case vr::Prop_HardwareRevision_String:
-    case vr::Prop_DisplayFirmwareVersion_String:
-    case vr::Prop_AttachedDeviceId_String:
     case vr::Prop_AllWirelessDongleDescriptions_String:
     case vr::Prop_ConnectedWirelessDongle_String:
     case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
     case vr::Prop_DisplayMCImageLeft_String:
     case vr::Prop_DisplayMCImageRight_String:
     case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_CameraFirmwareDescription_String:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_ModeLabel_String:
+    // could be any type
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
+    // Bool
     case vr::Prop_WillDriftInYaw_Bool:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-    case vr::Prop_DeviceBatteryPercentage_Float:
-    case vr::Prop_StatusDisplayTransform_Matrix34:
     case vr::Prop_Firmware_UpdateAvailable_Bool:
     case vr::Prop_Firmware_ManualUpdate_Bool:
-    case vr::Prop_HardwareRevision_Uint64:
-    case vr::Prop_FirmwareVersion_Uint64:
-    case vr::Prop_FPGAVersion_Uint64:
-    case vr::Prop_VRCVersion_Uint64:
-    case vr::Prop_RadioVersion_Uint64:
-    case vr::Prop_DongleVersion_Uint64:
     case vr::Prop_BlockServerShutdown_Bool:
     case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool:
     case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_IsOnDesktop_Bool:
+    // Float
+    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_SecondsFromVsyncToPhotons_Float:
     case vr::Prop_DisplayFrequency_Float:
     case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_IsOnDesktop_Bool:
-    case vr::Prop_DisplayMCType_Int32:
     case vr::Prop_DisplayMCOffset_Float:
     case vr::Prop_DisplayMCScale_Float:
-    case vr::Prop_EdidVendorID_Int32:
     case vr::Prop_DisplayGCBlackClamp_Float:
-    case vr::Prop_EdidProductID_Int32:
-    case vr::Prop_CameraToHeadTransform_Matrix34:
-    case vr::Prop_DisplayGCType_Int32:
     case vr::Prop_DisplayGCOffset_Float:
     case vr::Prop_DisplayGCScale_Float:
     case vr::Prop_DisplayGCPrescale_Float:
@@ -416,22 +445,38 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
     case vr::Prop_LensCenterRightU_Float:
     case vr::Prop_LensCenterRightV_Float:
     case vr::Prop_UserHeadToEyeDepthMeters_Float:
-    case vr::Prop_CameraFirmwareVersion_Uint64:
-    case vr::Prop_SupportedButtons_Uint64:
-    case vr::Prop_Axis0Type_Int32:
-    case vr::Prop_Axis1Type_Int32:
-    case vr::Prop_Axis2Type_Int32:
-    case vr::Prop_Axis3Type_Int32:
-    case vr::Prop_Axis4Type_Int32:
     case vr::Prop_FieldOfViewLeftDegrees_Float:
     case vr::Prop_FieldOfViewRightDegrees_Float:
     case vr::Prop_FieldOfViewTopDegrees_Float:
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-    default:
+    // Int32
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    // Uint64
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    // Matrix34
+    case vr::Prop_StatusDisplayTransform_Matrix34:
+    case vr::Prop_CameraToHeadTransform_Matrix34:
         return true;
     }
 }
@@ -442,77 +487,86 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, vr::HmdMatrix34_t)
     {
     case vr::Prop_StatusDisplayTransform_Matrix34:
     case vr::Prop_CameraToHeadTransform_Matrix34:
+    // could be any type
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return false;
-    case vr::Prop_TrackingSystemName_String:
-    case vr::Prop_ModelNumber_String:
-    case vr::Prop_SerialNumber_String:
-    case vr::Prop_RenderModelName_String:
+    // Bool
     case vr::Prop_WillDriftInYaw_Bool:
-    case vr::Prop_ManufacturerName_String:
-    case vr::Prop_TrackingFirmwareVersion_String:
-    case vr::Prop_HardwareRevision_String:
-    case vr::Prop_AllWirelessDongleDescriptions_String:
-    case vr::Prop_ConnectedWirelessDongle_String:
     case vr::Prop_DeviceIsWireless_Bool:
     case vr::Prop_DeviceIsCharging_Bool:
-    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_Firmware_UpdateAvailable_Bool:
     case vr::Prop_Firmware_ManualUpdate_Bool:
-    case vr::Prop_Firmware_ManualUpdateURL_String:
-    case vr::Prop_HardwareRevision_Uint64:
-    case vr::Prop_FirmwareVersion_Uint64:
-    case vr::Prop_FPGAVersion_Uint64:
-    case vr::Prop_VRCVersion_Uint64:
-    case vr::Prop_RadioVersion_Uint64:
-    case vr::Prop_DongleVersion_Uint64:
     case vr::Prop_BlockServerShutdown_Bool:
     case vr::Prop_CanUnifyCoordinateSystemWithHmd_Bool:
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool:
     case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_IsOnDesktop_Bool:
+    // Float
+    case vr::Prop_DeviceBatteryPercentage_Float:
     case vr::Prop_SecondsFromVsyncToPhotons_Float:
     case vr::Prop_DisplayFrequency_Float:
     case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_DisplayFirmwareVersion_String:
-    case vr::Prop_IsOnDesktop_Bool:
-    case vr::Prop_DisplayMCType_Int32:
     case vr::Prop_DisplayMCOffset_Float:
     case vr::Prop_DisplayMCScale_Float:
-    case vr::Prop_EdidVendorID_Int32:
-    case vr::Prop_DisplayMCImageLeft_String:
-    case vr::Prop_DisplayMCImageRight_String:
     case vr::Prop_DisplayGCBlackClamp_Float:
-    case vr::Prop_EdidProductID_Int32:
-    case vr::Prop_DisplayGCType_Int32:
     case vr::Prop_DisplayGCOffset_Float:
     case vr::Prop_DisplayGCScale_Float:
     case vr::Prop_DisplayGCPrescale_Float:
-    case vr::Prop_DisplayGCImage_String:
     case vr::Prop_LensCenterLeftU_Float:
     case vr::Prop_LensCenterLeftV_Float:
     case vr::Prop_LensCenterRightU_Float:
     case vr::Prop_LensCenterRightV_Float:
     case vr::Prop_UserHeadToEyeDepthMeters_Float:
-    case vr::Prop_CameraFirmwareVersion_Uint64:
-    case vr::Prop_AttachedDeviceId_String:
-    case vr::Prop_SupportedButtons_Uint64:
-    case vr::Prop_Axis0Type_Int32:
-    case vr::Prop_Axis1Type_Int32:
-    case vr::Prop_Axis2Type_Int32:
-    case vr::Prop_Axis3Type_Int32:
-    case vr::Prop_Axis4Type_Int32:
     case vr::Prop_FieldOfViewLeftDegrees_Float:
     case vr::Prop_FieldOfViewRightDegrees_Float:
     case vr::Prop_FieldOfViewTopDegrees_Float:
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-    default:
+    // Int32
+    case vr::Prop_DisplayMCType_Int32:
+    case vr::Prop_EdidVendorID_Int32:
+    case vr::Prop_EdidProductID_Int32:
+    case vr::Prop_DisplayGCType_Int32:
+    case vr::Prop_Axis0Type_Int32:
+    case vr::Prop_Axis1Type_Int32:
+    case vr::Prop_Axis2Type_Int32:
+    case vr::Prop_Axis3Type_Int32:
+    case vr::Prop_Axis4Type_Int32:
+    // Uint64
+    case vr::Prop_HardwareRevision_Uint64:
+    case vr::Prop_FirmwareVersion_Uint64:
+    case vr::Prop_FPGAVersion_Uint64:
+    case vr::Prop_VRCVersion_Uint64:
+    case vr::Prop_RadioVersion_Uint64:
+    case vr::Prop_DongleVersion_Uint64:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
+    case vr::Prop_CameraFirmwareVersion_Uint64:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
+    case vr::Prop_SupportedButtons_Uint64:
+    // String
+    case vr::Prop_TrackingSystemName_String:
+    case vr::Prop_ModelNumber_String:
+    case vr::Prop_SerialNumber_String:
+    case vr::Prop_RenderModelName_String:
+    case vr::Prop_ManufacturerName_String:
+    case vr::Prop_TrackingFirmwareVersion_String:
+    case vr::Prop_HardwareRevision_String:
+    case vr::Prop_AllWirelessDongleDescriptions_String:
+    case vr::Prop_ConnectedWirelessDongle_String:
+    case vr::Prop_Firmware_ManualUpdateURL_String:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
+    case vr::Prop_DisplayMCImageLeft_String:
+    case vr::Prop_DisplayMCImageRight_String:
+    case vr::Prop_DisplayGCImage_String:
+    case vr::Prop_CameraFirmwareDescription_String:
+    case vr::Prop_AttachedDeviceId_String:
+    case vr::Prop_ModeLabel_String:
         return true;
     }
 }
@@ -549,6 +603,18 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_ContainsProximitySensor_Bool:
     case vr::Prop_DeviceProvidesBatteryStatus_Bool:
     case vr::Prop_DeviceCanPowerOff_Bool:
+    case vr::Prop_Firmware_ProgrammingTarget_String:
+        return false;
+
+    // Properties that are unique to TrackedDeviceClass_HMD
+    case vr::Prop_ReportsTimeSinceVSync_Bool:
+    case vr::Prop_SecondsFromVsyncToPhotons_Float:
+    case vr::Prop_DisplayFrequency_Float:
+    case vr::Prop_UserIpdMeters_Float:
+    case vr::Prop_CurrentUniverseId_Uint64:
+    case vr::Prop_PreviousUniverseId_Uint64:
+    case vr::Prop_DisplayFirmwareVersion_Uint64:
+    case vr::Prop_IsOnDesktop_Bool:
     case vr::Prop_DisplayMCType_Int32:
     case vr::Prop_DisplayMCOffset_Float:
     case vr::Prop_DisplayMCScale_Float:
@@ -569,19 +635,8 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_LensCenterRightV_Float:
     case vr::Prop_UserHeadToEyeDepthMeters_Float:
     case vr::Prop_CameraFirmwareVersion_Uint64:
-    case vr::Prop_VendorSpecific_Reserved_Start:
-    case vr::Prop_VendorSpecific_Reserved_End:
-        return false;
-
-    // Properties that are unique to TrackedDeviceClass_HMD
-    case vr::Prop_ReportsTimeSinceVSync_Bool:
-    case vr::Prop_SecondsFromVsyncToPhotons_Float:
-    case vr::Prop_DisplayFrequency_Float:
-    case vr::Prop_UserIpdMeters_Float:
-    case vr::Prop_CurrentUniverseId_Uint64:
-    case vr::Prop_PreviousUniverseId_Uint64:
-    case vr::Prop_DisplayFirmwareVersion_String:
-    case vr::Prop_IsOnDesktop_Bool:
+    case vr::Prop_CameraFirmwareDescription_String:
+    case vr::Prop_DisplayFPGAVersion_Uint64:
         return (vr::TrackedDeviceClass_HMD != device_class);
 
     // Properties that are unique to TrackedDeviceClass_Controller
@@ -601,9 +656,12 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ModeLabel_String:
         return (vr::TrackedDeviceClass_TrackingReference != device_class);
 
-    default:
+	// Vendors are free to expose private debug data in this reserved region
+    case vr::Prop_VendorSpecific_Reserved_Start:
+    case vr::Prop_VendorSpecific_Reserved_End:
         return true;
     }
 }

--- a/osvr_tracked_device.h
+++ b/osvr_tracked_device.h
@@ -776,10 +776,6 @@ uint32_t OSVRTrackedDevice::GetStringTrackedDeviceProperty(vr::ETrackedDevicePro
         if (error)
             *error = vr::TrackedProp_ValueNotProvidedByDevice;
         return default_value;
-    case vr::Prop_DisplayFirmwareVersion_String: // TODO
-        if (error)
-            *error = vr::TrackedProp_ValueNotProvidedByDevice;
-        return default_value;
     case vr::Prop_AttachedDeviceId_String: // TODO
         if (error)
             *error = vr::TrackedProp_ValueNotProvidedByDevice;


### PR DESCRIPTION
This allows compiling with SteamVR/OpenVR 0.9.15. It is untested and likely won't work — it will probably be a few days before I'll have a chance to test it.
It also cleans up the device properties enum handling code and removes the default cases to ensure that all possible values are handled.