### PR TITLE
Return a universe ID of 0.

### DIFF
--- a/src/OSVRTrackedDevice.cpp
+++ b/src/OSVRTrackedDevice.cpp
@@ -613,14 +613,14 @@ uint64_t OSVRTrackedDevice::GetUint64TrackedDeviceProperty(vr::ETrackedDevicePro
             *error = vr::TrackedProp_ValueNotProvidedByDevice;
         return default_value;
     // Properties that are unique to TrackedDeviceClass_HMD
-    case vr::Prop_CurrentUniverseId_Uint64: // TODO
+    case vr::Prop_CurrentUniverseId_Uint64:
         if (error)
-            *error = vr::TrackedProp_ValueNotProvidedByDevice;
-        return default_value;
-    case vr::Prop_PreviousUniverseId_Uint64: // TODO
+            *error = vr::TrackedProp_Success;
+        return 0;
+    case vr::Prop_PreviousUniverseId_Uint64:
         if (error)
-            *error = vr::TrackedProp_ValueNotProvidedByDevice;
-        return default_value;
+            *error = vr::TrackedProp_Success;
+        return 0;
     case vr::Prop_DisplayFirmwareVersion_Uint64:
         if (error)
             *error = vr::TrackedProp_ValueNotProvidedByDevice;


### PR DESCRIPTION
Per a response from Valve:

> Fix these to gain access to chaperone and room setup:
> Current Universe ID:      0
> Previous Universe ID:    0
>
> (You can ignore previous and just return current.)

I've set both properties to always return 0.