### PR TITLE
Direct mode implementation via DXGI integrated into the steamvr plugin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,13 @@ add_library(driver_osvr
 	ServerDriver_OSVR.h
 	ValveStrCpy.h
 )
+
+if (WIN32)
+target_link_libraries(driver_osvr PRIVATE dxgi osvr::osvrClientKitCpp eigen-headers util-headers jsoncpp_lib)
+else()
 target_link_libraries(driver_osvr PRIVATE osvr::osvrClientKitCpp eigen-headers util-headers jsoncpp_lib)
+endif()
+
 target_include_directories(driver_osvr SYSTEM PRIVATE ${OPENVR_INCLUDE_DIRS})
 set_property(TARGET driver_osvr PROPERTY CXX_STANDARD 11)
 target_compile_features(driver_osvr PRIVATE cxx_override)

--- a/src/OSVRTrackedDevice.cpp
+++ b/src/OSVRTrackedDevice.cpp
@@ -47,7 +47,6 @@
 #include <string>
 #include <iostream>
 #include <exception>
-#include <d3d11_1.h>
 
 OSVRTrackedDevice::OSVRTrackedDevice(const std::string& display_description, osvr::clientkit::ClientContext& context, vr::IServerDriverHost* driver_host, vr::IDriverLog* driver_log) : m_DisplayDescription(display_description), m_Context(context), driver_host_(driver_host), logger_(driver_log), pose_(), deviceClass_(vr::TrackedDeviceClass_HMD)
 {

--- a/src/OSVRTrackedDevice.h
+++ b/src/OSVRTrackedDevice.h
@@ -37,6 +37,7 @@
 
 // Standard includes
 #include <string>
+#include <dxgi.h>
 
 class OSVRTrackedDevice : public vr::ITrackedDeviceServerDriver, public vr::IVRDisplayComponent {
 friend class ServerDriver_OSVR;
@@ -180,6 +181,12 @@ public:
 
 protected:
     const char* GetId();
+
+#ifdef _WINDOWS
+	// Copyright Razer LLC 2016
+	// Note: Need a general cross platform solution. This may be something that needs to be subsumed into the server functionality
+	bool findHMDMonitor(const char *HMDName, DXGI_OUTPUT_DESC *pOutputDesc);
+#endif
 
 private:
     std::string GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError *error);

--- a/src/OSVRTrackedDevice.h
+++ b/src/OSVRTrackedDevice.h
@@ -37,7 +37,10 @@
 
 // Standard includes
 #include <string>
+
+#ifdef _WINDOWS
 #include <dxgi.h>
+#endif
 
 class OSVRTrackedDevice : public vr::ITrackedDeviceServerDriver, public vr::IVRDisplayComponent {
 friend class ServerDriver_OSVR;


### PR DESCRIPTION
Features:
- supports direct mode for steam for Windows only
- no dependence on primary screen resolution or relative placement of HMD

Assumptions:
- only works for OSVR HDK at the moment
- requires the OSVR HDK driver to find the display

Caveats:
- not tested on OSX or Linux builds, however should compile and changes should not affect those platforms.
