### PR TITLE
Implement a tracking reference and fix Room Setup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,8 +40,8 @@ add_library(driver_osvr
 	Logging.h
 	OSVRTrackedDevice.cpp
 	OSVRTrackedDevice.h
-    OSVRTrackingReference.cpp
-    OSVRTrackingReference.h
+	OSVRTrackingReference.cpp
+	OSVRTrackingReference.h
 	ServerDriver_OSVR.cpp
 	ServerDriver_OSVR.h
 	Settings.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(driver_osvr
 	Logging.h
 	OSVRTrackedDevice.cpp
 	OSVRTrackedDevice.h
+    OSVRTrackingReference.cpp
+    OSVRTrackingReference.h
 	ServerDriver_OSVR.cpp
 	ServerDriver_OSVR.h
 	Settings.h

--- a/src/OSVRTrackedDevice.cpp
+++ b/src/OSVRTrackedDevice.cpp
@@ -70,6 +70,8 @@ OSVRTrackedDevice::~OSVRTrackedDevice()
 
 vr::EVRInitError OSVRTrackedDevice::Activate(uint32_t object_id)
 {
+    objectId_ = object_id;
+
     const std::time_t waitTime = 5; // wait up to 5 seconds for init
 
     // Register tracker callback
@@ -907,7 +909,7 @@ void OSVRTrackedDevice::HmdTrackerCallback(void* userdata, const OSVR_TimeValue*
     pose.shouldApplyHeadModel = true;
 
     self->pose_ = pose;
-    self->driver_host_->TrackedDevicePoseUpdated(0, self->pose_); /// @fixme figure out ID correctly, don't hardcode to zero
+    self->driver_host_->TrackedDevicePoseUpdated(self->objectId_, self->pose_);
 }
 
 float OSVRTrackedDevice::GetIPD()

--- a/src/OSVRTrackedDevice.cpp
+++ b/src/OSVRTrackedDevice.cpp
@@ -637,11 +637,11 @@ uint64_t OSVRTrackedDevice::GetUint64TrackedDeviceProperty(vr::ETrackedDevicePro
     case vr::Prop_CurrentUniverseId_Uint64:
         if (error)
             *error = vr::TrackedProp_Success;
-        return 0;
+        return 1;
     case vr::Prop_PreviousUniverseId_Uint64:
         if (error)
             *error = vr::TrackedProp_Success;
-        return 0;
+        return 1;
     case vr::Prop_DisplayFirmwareVersion_Uint64:
         /// @todo This really should be read from the server
         if (error)

--- a/src/OSVRTrackedDevice.cpp
+++ b/src/OSVRTrackedDevice.cpp
@@ -171,6 +171,10 @@ void OSVRTrackedDevice::DebugRequest(const char* request, char* response_buffer,
 {
     // TODO
     // make use of (from vrtypes.h) static const uint32_t k_unMaxDriverDebugResponseSize = 32768;
+    // return empty string for now
+    if (response_buffer_size > 0) {
+        response_buffer[0] = '\0';
+    }
 }
 
 void OSVRTrackedDevice::GetWindowBounds(int32_t* x, int32_t* y, uint32_t* width, uint32_t* height)

--- a/src/OSVRTrackedDevice.h
+++ b/src/OSVRTrackedDevice.h
@@ -209,6 +209,7 @@ private:
     vr::DriverPose_t pose_;
     vr::ETrackedDeviceClass deviceClass_;
     std::unique_ptr<Settings> settings_;
+    uint32_t objectId_ = 0;
 
     // Settings
     bool verboseLogging_ = false;

--- a/src/OSVRTrackingReference.cpp
+++ b/src/OSVRTrackingReference.cpp
@@ -1,0 +1,379 @@
+// Internal Includes
+#include "OSVRTrackingReference.h"
+#include "Logging.h"
+
+#include "osvr_compiler_detection.h"
+#include "make_unique.h"
+#include "matrix_cast.h"
+#include "osvr_device_properties.h"
+#include "ValveStrCpy.h"
+#include "platform_fixes.h" // strcasecmp
+#include "make_unique.h"
+#include "osvr_platform.h"
+
+// OpenVR includes
+#include <openvr_driver.h>
+
+// Library/third-party includes
+#include <osvr/Util/EigenInterop.h>
+#include <util/FixedLengthStringFunctions.h>
+
+// Standard includes
+#include <cstring>
+#include <ctime>
+#include <string>
+#include <iostream>
+#include <exception>
+//#include <fstream>
+//#include <algorithm>        // for std::find
+
+OSVRTrackingReference::OSVRTrackingReference(osvr::clientkit::ClientContext& context, vr::IServerDriverHost* driver_host, vr::IDriverLog* driver_log) : m_Context(context), driver_host_(driver_host), deviceClass_(vr::TrackedDeviceClass_TrackingReference)
+{
+    settings_ = std::make_unique<Settings>(driver_host->GetSettings(vr::IVRSettings_Version));
+    if (driver_log) {
+        Logging::instance().setDriverLog(driver_log);
+    }
+    configure();
+}
+
+OSVRTrackingReference::~OSVRTrackingReference()
+{
+    driver_host_ = nullptr;
+}
+
+vr::EVRInitError OSVRTrackingReference::Activate(uint32_t object_id)
+{
+    return vr::VRInitError_None;
+}
+
+void OSVRTrackingReference::Deactivate()
+{
+}
+
+void OSVRTrackingReference::PowerOff()
+{
+}
+
+void* OSVRTrackingReference::GetComponent(const char* component_name_and_version)
+{
+    return NULL;
+}
+
+
+void OSVRTrackingReference::DebugRequest(const char* request, char* response_buffer, uint32_t response_buffer_size)
+{
+    // TODO
+    // make use of (from vrtypes.h) static const uint32_t k_unMaxDriverDebugResponseSize = 32768;
+    // return empty string for now
+    if (response_buffer_size > 0) {
+        response_buffer[0] = '\0';
+    }
+}
+
+vr::DriverPose_t OSVRTrackingReference::GetPose()
+{
+    vr::DriverPose_t pose;
+    pose.poseTimeOffset = 0; // close enough
+    Eigen::Vector3d::Map(pose.vecWorldFromDriverTranslation) = Eigen::Vector3d::Zero();
+    Eigen::Vector3d::Map(pose.vecDriverFromHeadTranslation) = Eigen::Vector3d::Zero();
+    map(pose.qWorldFromDriverRotation) = Eigen::Quaterniond::Identity();
+    map(pose.qDriverFromHeadRotation) = Eigen::Quaterniond::Identity();
+    
+    // Position
+    Eigen::Vector3d::Map(pose.vecPosition) = Eigen::Vector3d::Zero();
+
+    // Position velocity and acceleration are not currently consistently provided
+    Eigen::Vector3d::Map(pose.vecVelocity) = Eigen::Vector3d::Zero();
+    Eigen::Vector3d::Map(pose.vecAcceleration) = Eigen::Vector3d::Zero();
+    
+    // Orientation
+    map(pose.qRotation) = Eigen::Quaterniond::Identity();
+    
+    // Angular velocity and acceleration are not currently consistently provided
+    Eigen::Vector3d::Map(pose.vecAngularVelocity) = Eigen::Vector3d::Zero();
+    Eigen::Vector3d::Map(pose.vecAngularAcceleration) = Eigen::Vector3d::Zero();
+
+    pose.result = vr::TrackingResult_Running_OK;
+    pose.poseIsValid = true;
+    pose.willDriftInYaw = false;
+    pose.shouldApplyHeadModel = false;
+    
+    return pose;
+}
+
+bool OSVRTrackingReference::GetBoolTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error)
+{
+    const bool default_value = false;
+
+    if (isWrongDataType(prop, bool())) {
+        if (error)
+            *error = vr::TrackedProp_WrongDataType;
+        return default_value;
+    }
+
+    if (isWrongDeviceClass(prop, deviceClass_)) {
+        if (error)
+            *error = vr::TrackedProp_WrongDeviceClass;
+        return default_value;
+    }
+
+    if (vr::TrackedDeviceClass_Invalid == deviceClass_) {
+        if (error)
+            *error = vr::TrackedProp_InvalidDevice;
+        return default_value;
+    }
+
+    OSVR_LOG(trace) << "OSVRTrackingReference::GetBoolTrackedDeviceProperty(): Requested property: " << prop << "\n";
+    if(error)
+        *error = vr::TrackedProp_ValueNotProvidedByDevice;
+    return default_value;
+}
+
+float OSVRTrackingReference::GetFloatTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error)
+{
+    const float default_value = 0.0f;
+
+    if (isWrongDataType(prop, float())) {
+        if (error)
+            *error = vr::TrackedProp_WrongDataType;
+        return default_value;
+    }
+
+    if (isWrongDeviceClass(prop, deviceClass_)) {
+        if (error)
+            *error = vr::TrackedProp_WrongDeviceClass;
+        return default_value;
+    }
+
+    if (vr::TrackedDeviceClass_Invalid == deviceClass_) {
+        if (error)
+            *error = vr::TrackedProp_InvalidDevice;
+        return default_value;
+    }
+
+#include "ignore-warning/push"
+#include "ignore-warning/switch-enum"
+
+    OSVR_LOG(trace) << "OSVRTrackingReference::GetFloatTrackedDeviceProperty(): Requested property: " << prop << "\n";
+
+    switch (prop) {
+    // General properties that apply to all device classes
+    case vr::Prop_FieldOfViewLeftDegrees_Float:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return 45.0;
+    case vr::Prop_FieldOfViewRightDegrees_Float:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return 45.0;
+    case vr::Prop_FieldOfViewTopDegrees_Float:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return 45.0;
+    case vr::Prop_FieldOfViewBottomDegrees_Float:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return 45.0;
+    case vr::Prop_TrackingRangeMinimumMeters_Float:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return 0.0;
+    case vr::Prop_TrackingRangeMaximumMeters_Float:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return 10.0;
+    default:
+        if (error)
+            *error = vr::TrackedProp_ValueNotProvidedByDevice;
+        return default_value;
+    }
+#include "ignore-warning/pop"
+}
+
+int32_t OSVRTrackingReference::GetInt32TrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error)
+{
+    const int32_t default_value = 0;
+
+    if (isWrongDataType(prop, int32_t())) {
+        if (error)
+            *error = vr::TrackedProp_WrongDataType;
+        return default_value;
+    }
+
+    if (isWrongDeviceClass(prop, deviceClass_)) {
+        if (error)
+            *error = vr::TrackedProp_WrongDeviceClass;
+        return default_value;
+    }
+
+    if (vr::TrackedDeviceClass_Invalid == deviceClass_) {
+        if (error)
+            *error = vr::TrackedProp_InvalidDevice;
+        return default_value;
+    }
+
+#include "ignore-warning/push"
+#include "ignore-warning/switch-enum"
+
+    OSVR_LOG(trace) << "OSVRTrackingReference::GetInt32TrackedDeviceProperty(): Requested property: " << prop << "\n";
+
+    switch (prop) {
+    // General properties that apply to all device classes
+    case vr::Prop_DeviceClass_Int32:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return deviceClass_;
+    default:
+        if (error)
+            *error = vr::TrackedProp_ValueNotProvidedByDevice;
+        return default_value;
+    }
+#include "ignore-warning/pop"
+}
+
+uint64_t OSVRTrackingReference::GetUint64TrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error)
+{
+    const uint64_t default_value = 0;
+
+    if (isWrongDataType(prop, uint64_t())) {
+        if (error)
+            *error = vr::TrackedProp_WrongDataType;
+        return default_value;
+    }
+
+    if (isWrongDeviceClass(prop, deviceClass_)) {
+        if (error)
+            *error = vr::TrackedProp_WrongDeviceClass;
+        return default_value;
+    }
+
+    if (vr::TrackedDeviceClass_Invalid == deviceClass_) {
+        if (error)
+            *error = vr::TrackedProp_InvalidDevice;
+        return default_value;
+    }
+
+    OSVR_LOG(trace) << "OSVRTrackingReference::GetUint64TrackedDeviceProperty(): Requested property: " << prop << "\n";
+    if(error)
+        *error = vr::TrackedProp_ValueNotProvidedByDevice;
+    return default_value;
+}
+
+vr::HmdMatrix34_t OSVRTrackingReference::GetMatrix34TrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error)
+{
+    // Default value is identity matrix
+    vr::HmdMatrix34_t default_value;
+    map(default_value) = Matrix34f::Identity();
+
+    if (isWrongDataType(prop, vr::HmdMatrix34_t())) {
+        if (error)
+            *error = vr::TrackedProp_WrongDataType;
+        return default_value;
+    }
+
+    if (isWrongDeviceClass(prop, deviceClass_)) {
+        if (error)
+            *error = vr::TrackedProp_WrongDeviceClass;
+        return default_value;
+    }
+
+    if (vr::TrackedDeviceClass_Invalid == deviceClass_) {
+        if (error)
+            *error = vr::TrackedProp_InvalidDevice;
+        return default_value;
+    }
+
+    OSVR_LOG(trace) << "OSVRTrackingReference::GetMatrix34TrackedDeviceProperty(): Requested property: " << prop << "\n";
+    if(error)
+        *error = vr::TrackedProp_ValueNotProvidedByDevice;
+    return default_value;
+}
+
+uint32_t OSVRTrackingReference::GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, char *pchValue, uint32_t unBufferSize, vr::ETrackedPropertyError *pError)
+{
+    uint32_t default_value = 0;
+    if (isWrongDataType(prop, pchValue)) {
+        if (pError)
+            *pError = vr::TrackedProp_WrongDataType;
+        return default_value;
+    }
+
+    if (isWrongDeviceClass(prop, deviceClass_)) {
+        if (pError)
+            *pError = vr::TrackedProp_WrongDeviceClass;
+        return default_value;
+    }
+
+    if (vr::TrackedDeviceClass_Invalid == deviceClass_) {
+        if (pError)
+            *pError = vr::TrackedProp_InvalidDevice;
+        return default_value;
+    }
+
+    OSVR_LOG(trace) << "OSVRTrackingReference::GetStringTrackedDeviceProperty(): Requested property: " << prop << "\n";
+
+    std::string sValue = GetStringTrackedDeviceProperty(prop, pError);
+    if (*pError == vr::TrackedProp_Success) {
+        if (sValue.size() + 1 > unBufferSize) {
+            *pError = vr::TrackedProp_BufferTooSmall;
+        } else {
+            valveStrCpy(sValue, pchValue, unBufferSize);
+        }
+        return static_cast<uint32_t>(sValue.size()) + 1;
+    }
+
+    return 0;
+}
+
+
+    // ------------------------------------
+    // Private Methods
+    // ------------------------------------
+
+std::string OSVRTrackingReference::GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError *error)
+{
+    std::string default_value = "";
+
+#include "ignore-warning/push"
+#include "ignore-warning/switch-enum"
+
+    switch (prop) {
+    // General properties that apply to all device classes
+    case vr::Prop_TrackingSystemName_String:
+        if (error)
+            *error = vr::TrackedProp_ValueNotProvidedByDevice;
+        return default_value;
+    case vr::Prop_ModelNumber_String:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return "OSVR HMD";
+    case vr::Prop_SerialNumber_String:
+        if (error)
+            *error = vr::TrackedProp_Success;
+        return "OSVR_HMD_Camera_1";
+    case vr::Prop_RenderModelName_String:
+        if (error)
+            *error = vr::TrackedProp_ValueNotProvidedByDevice;
+        return "dk2_camera";
+    default:
+        if (error)
+            *error = vr::TrackedProp_ValueNotProvidedByDevice;
+        return default_value;
+    }
+#include "ignore-warning/pop"
+}
+
+
+
+void OSVRTrackingReference::configure()
+{
+    // Get settings from config file
+    const bool verbose_logging = settings_->getSetting<bool>("verbose", false);
+    if (verbose_logging) {
+        OSVR_LOG(info) << "Verbose logging enabled.";
+        Logging::instance().setLogLevel(trace);
+    } else {
+        OSVR_LOG(info) << "Verbose logging disabled.";
+        Logging::instance().setLogLevel(info);
+    }
+}

--- a/src/OSVRTrackingReference.cpp
+++ b/src/OSVRTrackingReference.cpp
@@ -340,7 +340,7 @@ std::string OSVRTrackingReference::GetStringTrackedDeviceProperty(vr::ETrackedDe
         return "OSVR_HMD_Camera_1";
     case vr::Prop_RenderModelName_String:
         if (error)
-            *error = vr::TrackedProp_ValueNotProvidedByDevice;
+            *error = vr::TrackedProp_Success;
         return "dk2_camera";
     default:
         if (error)

--- a/src/OSVRTrackingReference.cpp
+++ b/src/OSVRTrackingReference.cpp
@@ -561,14 +561,14 @@ void OSVRTrackingReference::TrackerCallback(void* userdata, const OSVR_TimeValue
     map(pose.qDriverFromHeadRotation) = Eigen::Quaterniond::Identity();
 
     // Position
-    Eigen::Vector3d::Map(pose.vecPosition) = Eigen::Vector3d::Zero();
+    Eigen::Vector3d::Map(pose.vecPosition) = osvr::util::vecMap(report->pose.translation);
 
     // Position velocity and acceleration are not currently consistently provided
     Eigen::Vector3d::Map(pose.vecVelocity) = Eigen::Vector3d::Zero();
     Eigen::Vector3d::Map(pose.vecAcceleration) = Eigen::Vector3d::Zero();
 
     // Orientation
-    map(pose.qRotation) = Eigen::Quaterniond::Identity();
+    map(pose.qRotation) = osvr::util::fromQuat(report->pose.rotation);
 
     // Angular velocity and acceleration are not currently consistently provided
     Eigen::Vector3d::Map(pose.vecAngularVelocity) = Eigen::Vector3d::Zero();

--- a/src/OSVRTrackingReference.h
+++ b/src/OSVRTrackingReference.h
@@ -1,0 +1,156 @@
+/** @file
+    @brief OSVR tracking reference
+
+    @date 2015
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2015 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_OSVRTrackingReference_h_GUID_250D4551_4054_9D37_A8F6_F2FCFDB1C188
+#define INCLUDED_OSVRTrackingReference_h_GUID_250D4551_4054_9D37_A8F6_F2FCFDB1C188
+
+// Internal Includes
+#include "osvr_compiler_detection.h"    // for OSVR_OVERRIDE
+#include "Settings.h"
+
+// OpenVR includes
+#include <openvr_driver.h>
+
+// Library/third-party includes
+#include <osvr/ClientKit/Display.h>
+#include <osvr/Client/RenderManagerConfig.h>
+
+// Standard includes
+#include <string>
+#include <memory>
+
+class OSVRTrackingReference : public vr::ITrackedDeviceServerDriver {
+friend class ServerDriver_OSVR;
+public:
+    OSVRTrackingReference(osvr::clientkit::ClientContext& context, vr::IServerDriverHost* driver_host, vr::IDriverLog* driver_log = nullptr);
+
+    virtual ~OSVRTrackingReference();
+    
+   // ------------------------------------
+   // Management Methods
+   // ------------------------------------
+   /**
+    * This is called before an HMD is returned to the application. It will
+    * always be called before any display or tracking methods. Memory and
+    * processor use by the ITrackedDeviceServerDriver object should be kept to
+    * a minimum until it is activated.  The pose listener is guaranteed to be
+    * valid until Deactivate is called, but should not be used after that
+    * point.
+    */
+   virtual vr::EVRInitError Activate(uint32_t object_id) OSVR_OVERRIDE;
+
+   /**
+    * This is called when The VR system is switching from this Hmd being the
+    * active display to another Hmd being the active display. The driver should
+    * clean whatever memory and thread use it can when it is deactivated.
+    */
+   virtual void Deactivate() OSVR_OVERRIDE;
+
+   /**
+    * Handles a request from the system to power off this device.
+    */
+   virtual void PowerOff() OSVR_OVERRIDE;
+
+   /**
+    * Requests a component interface of the driver for device-specific
+    * functionality. The driver should return NULL if the requested interface
+    * or version is not supported.
+    */
+   virtual void* GetComponent(const char* component_name_and_version) OSVR_OVERRIDE;
+
+   /**
+    * A VR Client has made this debug request of the driver. The set of valid
+    * requests is entirely up to the driver and the client to figure out, as is
+    * the format of the response. Responses that exceed the length of the
+    * supplied buffer should be truncated and null terminated.
+    */
+   virtual void DebugRequest(const char* request, char* response_buffer, uint32_t response_buffer_size) OSVR_OVERRIDE;
+
+
+    // ------------------------------------
+    // Tracking Methods
+    // ------------------------------------
+    virtual vr::DriverPose_t GetPose() OSVR_OVERRIDE;
+
+    // ------------------------------------
+    // Property Methods
+    // ------------------------------------
+
+    /**
+     * Returns a bool property. If the property is not available this function
+     * will return false.
+     */
+    virtual bool GetBoolTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
+
+    /**
+     * Returns a float property. If the property is not available this function
+     * will return 0.
+     */
+    virtual float GetFloatTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
+
+    /**
+     * Returns an int property. If the property is not available this function
+     * will return 0.
+     */
+    virtual int32_t GetInt32TrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
+
+    /**
+     * Returns a uint64 property. If the property is not available this function
+     * will return 0.
+     */
+    virtual uint64_t GetUint64TrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
+
+    /**
+     * Returns a matrix property. If the device index is not valid or the
+     * property is not a matrix type, this function will return identity.
+     */
+    virtual vr::HmdMatrix34_t GetMatrix34TrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
+
+    /**
+     * Returns a string property. If the property is not available this function
+     * will return 0 and @p error will be set to an error. Otherwise it returns
+     * the length of the number of bytes necessary to hold this string including
+     * the trailing null. If the buffer is too small the error will be
+     * @c TrackedProp_BufferTooSmall. Strings will generally fit in buffers of
+     * @c k_unTrackingStringSize characters. Drivers may not return strings longer
+     * than @c k_unMaxPropertyStringSize.
+     */
+    virtual uint32_t GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, char* value, uint32_t buffer_size, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
+    
+private:
+    std::string GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError *error);
+    void configure();
+    
+    osvr::clientkit::ClientContext& m_Context;
+    vr::IServerDriverHost* driver_host_ = nullptr;
+//    vr::DriverPose_t pose_;
+    vr::ETrackedDeviceClass deviceClass_;
+    std::unique_ptr<Settings> settings_;
+
+    // Settings
+    bool verboseLogging_ = false;
+    
+};
+
+#endif // INCLUDED_OSVRTrackingReference_h_GUID_250D4551_4054_9D37_A8F6_F2FCFDB1C188

--- a/src/OSVRTrackingReference.h
+++ b/src/OSVRTrackingReference.h
@@ -158,13 +158,14 @@ private:
 
     // Settings
     bool verboseLogging_ = false;
-    std::string trackerPath_ = "/camera";
+    std::string trackerPath_ = "/org_osvr_filter_videoimufusion/HeadFusion/semantic/camera";
 
     // Default values are those for the OSVR HDK IR camera
     float fovLeft_ = 35.235f; // degrees
     float fovRight_ = 35.235f; // degrees
     float fovTop_ = 27.95f; // degrees
     float fovBottom_ = 27.95f; // degrees
+
     float minTrackingRange_ = 0.15f; // meters
     float maxTrackingRange_ = 1.5f; // meters
 };

--- a/src/OSVRTrackingReference.h
+++ b/src/OSVRTrackingReference.h
@@ -140,11 +140,13 @@ public:
     
 private:
     std::string GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError *error);
+    static void RefTrackerCallback(void* userdata, const OSVR_TimeValue* timestamp, const OSVR_PoseReport* report);
     void configure();
     
     osvr::clientkit::ClientContext& m_Context;
     vr::IServerDriverHost* driver_host_ = nullptr;
-//    vr::DriverPose_t pose_;
+    osvr::clientkit::Interface m_TrackerInterface;
+    vr::DriverPose_t pose_;
     vr::ETrackedDeviceClass deviceClass_;
     std::unique_ptr<Settings> settings_;
 

--- a/src/OSVRTrackingReference.h
+++ b/src/OSVRTrackingReference.h
@@ -1,14 +1,14 @@
 /** @file
-    @brief OSVR tracking reference
+    @brief OSVR tracking reference (e.g., camera or base station)
 
-    @date 2015
+    @date 2016
 
     @author
     Sensics, Inc.
     <http://sensics.com/osvr>
 */
 
-// Copyright 2015 Sensics, Inc.
+// Copyright 2016 Sensics, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,8 +33,7 @@
 #include <openvr_driver.h>
 
 // Library/third-party includes
-#include <osvr/ClientKit/Display.h>
-#include <osvr/Client/RenderManagerConfig.h>
+#include <osvr/ClientKit/ClientKit.h>
 
 // Standard includes
 #include <string>
@@ -46,47 +45,46 @@ public:
     OSVRTrackingReference(osvr::clientkit::ClientContext& context, vr::IServerDriverHost* driver_host, vr::IDriverLog* driver_log = nullptr);
 
     virtual ~OSVRTrackingReference();
-    
-   // ------------------------------------
-   // Management Methods
-   // ------------------------------------
-   /**
-    * This is called before an HMD is returned to the application. It will
-    * always be called before any display or tracking methods. Memory and
-    * processor use by the ITrackedDeviceServerDriver object should be kept to
-    * a minimum until it is activated.  The pose listener is guaranteed to be
-    * valid until Deactivate is called, but should not be used after that
-    * point.
-    */
-   virtual vr::EVRInitError Activate(uint32_t object_id) OSVR_OVERRIDE;
 
-   /**
-    * This is called when The VR system is switching from this Hmd being the
-    * active display to another Hmd being the active display. The driver should
-    * clean whatever memory and thread use it can when it is deactivated.
-    */
-   virtual void Deactivate() OSVR_OVERRIDE;
+    // ------------------------------------
+    // Management Methods
+    // ------------------------------------
+    /**
+     * This is called before an HMD is returned to the application. It will
+     * always be called before any display or tracking methods. Memory and
+     * processor use by the ITrackedDeviceServerDriver object should be kept to
+     * a minimum until it is activated.  The pose listener is guaranteed to be
+     * valid until Deactivate is called, but should not be used after that
+     * point.
+     */
+    virtual vr::EVRInitError Activate(uint32_t object_id) OSVR_OVERRIDE;
 
-   /**
-    * Handles a request from the system to power off this device.
-    */
-   virtual void PowerOff() OSVR_OVERRIDE;
+    /**
+     * This is called when The VR system is switching from this Hmd being the
+     * active display to another Hmd being the active display. The driver should
+     * clean whatever memory and thread use it can when it is deactivated.
+     */
+    virtual void Deactivate() OSVR_OVERRIDE;
 
-   /**
-    * Requests a component interface of the driver for device-specific
-    * functionality. The driver should return NULL if the requested interface
-    * or version is not supported.
-    */
-   virtual void* GetComponent(const char* component_name_and_version) OSVR_OVERRIDE;
+    /**
+     * Handles a request from the system to power off this device.
+     */
+    virtual void PowerOff() OSVR_OVERRIDE;
 
-   /**
-    * A VR Client has made this debug request of the driver. The set of valid
-    * requests is entirely up to the driver and the client to figure out, as is
-    * the format of the response. Responses that exceed the length of the
-    * supplied buffer should be truncated and null terminated.
-    */
-   virtual void DebugRequest(const char* request, char* response_buffer, uint32_t response_buffer_size) OSVR_OVERRIDE;
+    /**
+     * Requests a component interface of the driver for device-specific
+     * functionality. The driver should return NULL if the requested interface
+     * or version is not supported.
+     */
+    virtual void* GetComponent(const char* component_name_and_version) OSVR_OVERRIDE;
 
+    /**
+     * A VR Client has made this debug request of the driver. The set of valid
+     * requests is entirely up to the driver and the client to figure out, as is
+     * the format of the response. Responses that exceed the length of the
+     * supplied buffer should be truncated and null terminated.
+     */
+    virtual void DebugRequest(const char* request, char* response_buffer, uint32_t response_buffer_size) OSVR_OVERRIDE;
 
     // ------------------------------------
     // Tracking Methods
@@ -137,22 +135,39 @@ public:
      * than @c k_unMaxPropertyStringSize.
      */
     virtual uint32_t GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, char* value, uint32_t buffer_size, vr::ETrackedPropertyError* error) OSVR_OVERRIDE;
-    
+
+protected:
+    const char* GetId();
+
 private:
     std::string GetStringTrackedDeviceProperty(vr::ETrackedDeviceProperty prop, vr::ETrackedPropertyError *error);
-    static void RefTrackerCallback(void* userdata, const OSVR_TimeValue* timestamp, const OSVR_PoseReport* report);
+    static void TrackerCallback(void* userdata, const OSVR_TimeValue* timestamp, const OSVR_PoseReport* report);
+
+    /**
+     * Read configuration settings from configuration file.
+     */
     void configure();
-    
+
     osvr::clientkit::ClientContext& m_Context;
     vr::IServerDriverHost* driver_host_ = nullptr;
     osvr::clientkit::Interface m_TrackerInterface;
     vr::DriverPose_t pose_;
     vr::ETrackedDeviceClass deviceClass_;
     std::unique_ptr<Settings> settings_;
+    uint32_t objectId_ = 0;
 
     // Settings
     bool verboseLogging_ = false;
-    
+    std::string trackerPath_ = "/camera";
+
+    // Default values are those for the OSVR HDK IR camera
+    float fovLeft_ = 35.235f; // degrees
+    float fovRight_ = 35.235f; // degrees
+    float fovTop_ = 27.95f; // degrees
+    float fovBottom_ = 27.95f; // degrees
+    float minTrackingRange_ = 0.15f; // meters
+    float maxTrackingRange_ = 1.5f; // meters
 };
 
-#endif // INCLUDED_OSVRTrackingReference_h_GUID_250D4551_4054_9D37_A8F6_F2FCFDB1C188
+#endif // INCLUDED_OSVRTrackingReference_h_GUID_4D3F2E76_D0A2_4876_A7E9_CF0E772B02EF
+

--- a/src/ServerDriver_OSVR.cpp
+++ b/src/ServerDriver_OSVR.cpp
@@ -87,11 +87,9 @@ vr::ITrackedDeviceServerDriver* ServerDriver_OSVR::GetTrackedDeviceDriver(uint32
 
 vr::ITrackedDeviceServerDriver* ServerDriver_OSVR::FindTrackedDeviceDriver(const char* id)
 {
-    char snString[64];
-    vr::ETrackedPropertyError properr;
     for (auto& tracked_device : trackedDevices_) {
-        tracked_device->GetStringTrackedDeviceProperty(vr::Prop_SerialNumber_String, snString, 64, &properr);
-        if (0 == std::strcmp(id, snString)) {
+        const auto device_id = getDeviceId(tracked_device.get());
+        if (0 == std::strcmp(id, device_id.c_str())) {
             OSVR_LOG(info) << "ServerDriver_OSVR::FindTrackedDeviceDriver(): Returning tracked device " << id << ".\n";
             return tracked_device.get();
         }
@@ -120,5 +118,17 @@ void ServerDriver_OSVR::EnterStandby()
 void ServerDriver_OSVR::LeaveStandby()
 {
     // TODO
+}
+
+std::string ServerDriver_OSVR::getDeviceId(vr::ITrackedDeviceServerDriver* device)
+{
+    char device_id[vr::k_unMaxPropertyStringSize];
+    vr::ETrackedPropertyError property_error;
+    device->GetStringTrackedDeviceProperty(vr::Prop_SerialNumber_String, device_id, vr::k_unMaxPropertyStringSize, &property_error);
+    if (vr::TrackedProp_Success == property_error) {
+        return device_id;
+    } else {
+        return "";
+    }
 }
 

--- a/src/ServerDriver_OSVR.cpp
+++ b/src/ServerDriver_OSVR.cpp
@@ -26,6 +26,7 @@
 #include "ServerDriver_OSVR.h"
 
 #include "OSVRTrackedDevice.h"      // for OSVRTrackedDevice
+#include "OSVRTrackingReference.h"  // for OSVRTrackingReference
 #include "platform_fixes.h"         // strcasecmp
 #include "make_unique.h"            // for std::make_unique
 #include "osvr_platform.h"          // for OSVR_PATH_SEPARATOR
@@ -50,6 +51,7 @@ vr::EVRInitError ServerDriver_OSVR::Init(vr::IDriverLog* driver_log, vr::IServer
 
     const std::string display_description = context_->getStringParameter("/display");
     trackedDevices_.emplace_back(std::make_unique<OSVRTrackedDevice>(display_description, *(context_.get()), driver_host));
+    trackedDevices_.emplace_back(std::make_unique<OSVRTrackingReference>(*(context_.get()), driver_host));
 
     return vr::VRInitError_None;
 }
@@ -85,8 +87,11 @@ vr::ITrackedDeviceServerDriver* ServerDriver_OSVR::GetTrackedDeviceDriver(uint32
 
 vr::ITrackedDeviceServerDriver* ServerDriver_OSVR::FindTrackedDeviceDriver(const char* id)
 {
+    char snString[64];
+    vr::ETrackedPropertyError properr;
     for (auto& tracked_device : trackedDevices_) {
-        if (0 == std::strcmp(id, tracked_device->GetId())) {
+        tracked_device->GetStringTrackedDeviceProperty(vr::Prop_SerialNumber_String, snString, 64, &properr);
+        if (0 == std::strcmp(id, snString)) {
             OSVR_LOG(info) << "ServerDriver_OSVR::FindTrackedDeviceDriver(): Returning tracked device " << id << ".\n";
             return tracked_device.get();
         }

--- a/src/ServerDriver_OSVR.h
+++ b/src/ServerDriver_OSVR.h
@@ -118,6 +118,11 @@ public:
     virtual void LeaveStandby() OSVR_OVERRIDE;
 
 private:
+    /**
+     * Returns the serial number of the tracked device.
+     */
+    std::string getDeviceId(vr::ITrackedDeviceServerDriver* device);
+
     std::vector<std::unique_ptr<vr::ITrackedDeviceServerDriver>> trackedDevices_;
     std::unique_ptr<osvr::clientkit::ClientContext> context_;
 };

--- a/src/ServerDriver_OSVR.h
+++ b/src/ServerDriver_OSVR.h
@@ -118,7 +118,7 @@ public:
     virtual void LeaveStandby() OSVR_OVERRIDE;
 
 private:
-    std::vector<std::unique_ptr<OSVRTrackedDevice>> trackedDevices_;
+    std::vector<std::unique_ptr<vr::ITrackedDeviceServerDriver>> trackedDevices_;
     std::unique_ptr<osvr::clientkit::ClientContext> context_;
 };
 

--- a/src/osvr_device_properties.h
+++ b/src/osvr_device_properties.h
@@ -79,6 +79,8 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const bool&)
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
     // Int32
     case vr::Prop_DeviceClass_Int32:
     case vr::Prop_DisplayMCType_Int32:
@@ -159,6 +161,8 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const float&)
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
     // could be any type
     case vr::Prop_VendorSpecific_Reserved_Start:
     case vr::Prop_VendorSpecific_Reserved_End:
@@ -289,6 +293,8 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const int32_t&)
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
     // Uint64
     case vr::Prop_HardwareRevision_Uint64:
     case vr::Prop_FirmwareVersion_Uint64:
@@ -392,6 +398,8 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const uint64_t&)
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
     // Int32
     case vr::Prop_DeviceClass_Int32:
     case vr::Prop_DisplayMCType_Int32:
@@ -494,6 +502,8 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, const char*)
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
     // Int32
     case vr::Prop_DeviceClass_Int32:
     case vr::Prop_DisplayMCType_Int32:
@@ -578,6 +588,8 @@ inline bool isWrongDataType(vr::ETrackedDeviceProperty prop, vr::HmdMatrix34_t)
     case vr::Prop_FieldOfViewBottomDegrees_Float:
     case vr::Prop_TrackingRangeMinimumMeters_Float:
     case vr::Prop_TrackingRangeMaximumMeters_Float:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
     // Int32
     case vr::Prop_DeviceClass_Int32:
     case vr::Prop_DisplayMCType_Int32:
@@ -705,6 +717,8 @@ inline bool isWrongDeviceClass(vr::ETrackedDeviceProperty prop, vr::ETrackedDevi
     case vr::Prop_DisplayHardwareVersion_Uint64:
     case vr::Prop_AudioFirmwareVersion_Uint64:
     case vr::Prop_CameraCompatibilityMode_Int32:
+    case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+    case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
         return (vr::TrackedDeviceClass_HMD != device_class);
 
     // Properties that are unique to TrackedDeviceClass_Controller

--- a/src/pretty_print.h
+++ b/src/pretty_print.h
@@ -183,6 +183,10 @@ inline std::string to_string(const vr::ETrackedDeviceProperty& value)
             return "Prop_AudioFirmwareVersion_Uint64";
         case vr::Prop_CameraCompatibilityMode_Int32:
             return "Prop_CameraCompatibilityMode_Int32";
+        case vr::Prop_ScreenshotHorizontalFieldOfViewDegrees_Float:
+            return "Prop_ScreenshotHorizontalFieldOfViewDegrees_Float";
+        case vr::Prop_ScreenshotVerticalFieldOfViewDegrees_Float:
+            return "Prop_ScreenshotVerticalFieldOfViewDegrees_Float";
         case vr::Prop_AttachedDeviceId_String:
             return "Prop_AttachedDeviceId_String";
         case vr::Prop_SupportedButtons_Uint64:

--- a/steamvr.vrsettings
+++ b/steamvr.vrsettings
@@ -6,7 +6,7 @@
     "driver_osvr": {
         "verbose": false,
         "displayName": "OSVR",
-        "cameraPath": "/camera",
+        "cameraPath": "/org_osvr_filter_videoimufusion/HeadFusion/semantic/camera",
         "cameraFOVLeftDegrees": 35.235,
         "cameraFOVRightDegrees": 35.235,
         "cameraFOVTopDegrees": 27.95,

--- a/steamvr.vrsettings
+++ b/steamvr.vrsettings
@@ -1,0 +1,18 @@
+{
+    "jsonid" : "vrsettings",
+    "steamvr" : {
+        "activateMultipleDrivers": true
+    },
+    "driver_osvr": {
+        "verbose": false,
+        "displayName": "OSVR",
+        "cameraPath": "/camera",
+        "cameraFOVLeftDegrees": 35.235,
+        "cameraFOVRightDegrees": 35.235,
+        "cameraFOVTopDegrees": 27.95,
+        "cameraFOVBottomDegrees": 27.95,
+        "minTrackingRangeMeters": 0.15,
+        "maxTrackingRangeMeters": 1.5
+    }
+}
+


### PR DESCRIPTION
This implements a "dummy" tracking reference. Currently it returns 0,0,0 for position and hardcoded, likely bogus values for camera parameters. Ideally these could be provided by OSVR-Core. However, it does add enough to allow Room Setup to display a tracking reference and the camera. Forwards-backwards position tracking is really bad though — is this a known issue?

Additionally, this fixes Room Setup being broken — https://github.com/d235j/SteamVR-OSVR/commit/f880ab0d610002704373fae4588ede7ca769ecdc fixes that problem, as it appears the universe id has to be >0 to be considered valid. The Vive driver returns a number that appears semi-random but is likely tied to the Vive's serial number, and the Rift driver returns "1".