### PR TITLE
Passing angular velocity from OSVR into SteamVR

### DIFF
--- a/src/AngVelTools.h
+++ b/src/AngVelTools.h
@@ -1,0 +1,62 @@
+/** @file
+    @brief Header
+
+    @date 2016
+
+    @author
+    Sensics, Inc.
+    <http://sensics.com/osvr>
+*/
+
+// Copyright 2016 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_AngVelTools_h_GUID_628878EF_DAFC_4486_36BC_6C47BD452AB0
+#define INCLUDED_AngVelTools_h_GUID_628878EF_DAFC_4486_36BC_6C47BD452AB0
+
+// Internal Includes
+// - none
+
+// Library/third-party includes
+#include <osvr/Util/EigenCoreGeometry.h>
+#include <osvr/Util/EigenQuatExponentialMap.h>
+
+// Standard includes
+#include <cmath>
+
+namespace osvr {
+namespace vbtracker {
+    /// use only for derivatives - has factor of 2/0.5 in it!
+  //  inline Eigen::Quaterniond
+  //  angVelVecToIncRot(Eigen::Vector3d const &angVelVec, double dt) {
+  //      return util::ei_quat_exp_map::quat_exp(angVelVec * dt * 0.5).normalized();
+  //  }
+//
+    /// use only for derivatives - has factor of 2/0.5 in it!
+    inline Eigen::Vector3d incRotToAngVelVec(Eigen::Quaterniond const &incRot,
+                                             double dt) {
+#if 0
+        if (incRot.w() >= 1. || incRot.vec().isZero(1e-10)) {
+            return Eigen::Vector3d::Zero();
+        }
+        auto angle = std::acos(incRot.w());
+        return incRot.vec().normalized() * angle * 2. / dt;
+#else
+        return util::ei_quat_exp_map::quat_ln(incRot) * 2. / dt;
+#endif
+    }
+
+} // namespace vbtracker
+} // namespace osvr
+#endif // INCLUDED_AngVelTools_h_GUID_628878EF_DAFC_4486_36BC_6C47BD452AB0

--- a/src/OSVRTrackedDevice.cpp
+++ b/src/OSVRTrackedDevice.cpp
@@ -860,7 +860,6 @@ void OSVRTrackedDevice::HmdTrackerCallback(void* userdata, const OSVR_TimeValue*
 	// Get angular velocity in correct format for SteamVR
 	OSVR_TimeValue timeval2;
 	OSVR_AngularVelocityState state;
-    auto* self = static_cast<OSVRTrackedDevice*>(userdata);
 	osvrGetAngularVelocityState(self->trackerInterface_.get(), &timeval2, &state);
 	double dt = state.dt;
 	Eigen::Quaterniond r = osvr::util::fromQuat(report->pose.rotation);


### PR DESCRIPTION
This seems to remove the "ticking" orientation judder when moving your head in SteamVR, but only works when not using one of the positional trackers - perhaps the tracking fusion is not passing through the angular velocity well enough currently, but the IMU certainly seems to be giving good enough data.