### PR TITLE
Capitalization error

### DIFF
--- a/src/OSVRDisplay.cpp
+++ b/src/OSVRDisplay.cpp
@@ -30,8 +30,8 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
-#include <osvr/display/DisplayIO.h>
+#include <osvr/Display/Display.h>
+#include <osvr/Display/DisplayIO.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 

--- a/src/OSVRDisplay.h
+++ b/src/OSVRDisplay.h
@@ -32,7 +32,7 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
+#include <osvr/Display/Display.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 


### PR DESCRIPTION
On case-sensitive filesystems (like those used in Linux), compilation fails because `#include <osvr/display/Display.h>` is looking for a lowercase D, whereas the actual directory begins with an uppercase D.

Updated instances of lowercase d in includes in OVRDisplay.cpp and OVRDisplay.h