### PR TITLE
fix OSVR-Display header include path

### DIFF
--- a/src/OSVRDisplay.cpp
+++ b/src/OSVRDisplay.cpp
@@ -30,8 +30,8 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
-#include <osvr/display/DisplayIO.h>
+#include <osvr/Display/Display.h>
+#include <osvr/Display/DisplayIO.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 

--- a/src/OSVRDisplay.h
+++ b/src/OSVRDisplay.h
@@ -32,7 +32,7 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
+#include <osvr/Display/Display.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 


### PR DESCRIPTION
It's `vendor/OSVR-Display/osvr/Display/Display.h`, not `vendor/OSVR-Display/osvr/display/Display.h`