### PR TITLE
fix include directive to respect case sensitive filesystems

### DIFF
--- a/src/OSVRDisplay.cpp
+++ b/src/OSVRDisplay.cpp
@@ -30,8 +30,8 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
-#include <osvr/display/DisplayIO.h>
+#include <osvr/Display/Display.h>
+#include <osvr/Display/DisplayIO.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 

--- a/src/OSVRDisplay.h
+++ b/src/OSVRDisplay.h
@@ -32,7 +32,7 @@
 // Library/third-party includes
 #include <openvr_driver.h>
 
-#include <osvr/display/Display.h>
+#include <osvr/Display/Display.h>
 #include <osvr/RenderKit/osvr_display_configuration.h>
 #include <osvr/Util/PlatformConfig.h>
 


### PR DESCRIPTION
Build failed on linux because those two #includes had a path component which was not in sync with the actual folder structure's case.